### PR TITLE
(GSoC) - Add coreference resolution, data collection, code cleanup, formatting

### DIFF
--- a/GSoC23/CoreferenceResolution/FCOREF.py
+++ b/GSoC23/CoreferenceResolution/FCOREF.py
@@ -1,0 +1,20 @@
+import spacy
+from fastcoref import spacy_component
+
+nlp = spacy.load("en_core_web_sm")
+nlp.add_pipe(
+    "fastcoref",
+    config={
+        'model_architecture': 'LingMessCoref', 
+        'model_path': 'biu-nlp/lingmess-coref', 
+        'device': 'cpu'}
+    )
+
+def get_coref_resolved_text(text):
+    global nlp
+    doc = nlp(
+    text,
+    component_cfg={"fastcoref": {'resolve_text': True}}
+    )
+
+    return doc._.resolved_text

--- a/GSoC23/CoreferenceResolution/FCOREF.py
+++ b/GSoC23/CoreferenceResolution/FCOREF.py
@@ -5,16 +5,15 @@ nlp = spacy.load("en_core_web_sm")
 nlp.add_pipe(
     "fastcoref",
     config={
-        'model_architecture': 'LingMessCoref', 
-        'model_path': 'biu-nlp/lingmess-coref', 
-        'device': 'cpu'}
-    )
+        "model_architecture": "LingMessCoref",
+        "model_path": "biu-nlp/lingmess-coref",
+        "device": "cpu",
+    },
+)
+
 
 def get_coref_resolved_text(text):
     global nlp
-    doc = nlp(
-    text,
-    component_cfg={"fastcoref": {'resolve_text': True}}
-    )
+    doc = nlp(text, component_cfg={"fastcoref": {"resolve_text": True}})
 
     return doc._.resolved_text

--- a/GSoC23/CoreferenceResolution/methods.py
+++ b/GSoC23/CoreferenceResolution/methods.py
@@ -1,0 +1,4 @@
+
+def resolve_coref_FCOREF(text):
+    from GSoC23.CoreferenceResolution.FCOREF import get_coref_resolved_text
+    return get_coref_resolved_text(text)

--- a/GSoC23/CoreferenceResolution/methods.py
+++ b/GSoC23/CoreferenceResolution/methods.py
@@ -1,4 +1,4 @@
-
 def resolve_coref_FCOREF(text):
     from GSoC23.CoreferenceResolution.FCOREF import get_coref_resolved_text
+
     return get_coref_resolved_text(text)

--- a/GSoC23/CoreferenceResolution/notebooks/fcoref.ipynb
+++ b/GSoC23/CoreferenceResolution/notebooks/fcoref.ipynb
@@ -1,0 +1,406 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/CoreferenceResolution/notebooks',\n",
+       " '/home/aakash/D/miniconda3/envs/gsoc/lib/python311.zip',\n",
+       " '/home/aakash/D/miniconda3/envs/gsoc/lib/python3.11',\n",
+       " '/home/aakash/D/miniconda3/envs/gsoc/lib/python3.11/lib-dynload',\n",
+       " '',\n",
+       " '/home/aakash/D/miniconda3/envs/gsoc/lib/python3.11/site-packages',\n",
+       " '/home/aakash/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/IPython/extensions',\n",
+       " '/home/aakash/.ipython',\n",
+       " '/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23']"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23\")\n",
+    "sys.path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/aakash/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Downloading (…)lve/main/config.json: 100%|██████████| 1.22k/1.22k [00:00<00:00, 2.24MB/s]\n",
+      "Downloading (…)okenizer_config.json: 100%|██████████| 361/361 [00:00<00:00, 1.00MB/s]\n",
+      "Downloading (…)olve/main/vocab.json: 100%|██████████| 798k/798k [00:00<00:00, 1.08MB/s]\n",
+      "Downloading (…)olve/main/merges.txt: 100%|██████████| 456k/456k [00:00<00:00, 709kB/s]\n",
+      "Downloading (…)/main/tokenizer.json: 100%|██████████| 1.36M/1.36M [00:00<00:00, 3.92MB/s]\n",
+      "Downloading (…)cial_tokens_map.json: 100%|██████████| 239/239 [00:00<00:00, 651kB/s]\n",
+      "Downloading pytorch_model.bin: 100%|██████████| 2.36G/2.36G [12:53<00:00, 3.05MB/s]\n",
+      "08/20/2023 22:55:19 - INFO - \t missing_keys: []\n",
+      "08/20/2023 22:55:19 - INFO - \t unexpected_keys: []\n",
+      "08/20/2023 22:55:19 - INFO - \t mismatched_keys: []\n",
+      "08/20/2023 22:55:19 - INFO - \t error_msgs: []\n",
+      "08/20/2023 22:55:19 - INFO - \t Model Parameters: 590.0M, Transformer: 434.6M, Coref head: 155.4M\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<fastcoref.spacy_component.spacy_component.FastCorefResolver at 0x7fe3351c54d0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from fastcoref import spacy_component\n",
+    "import spacy\n",
+    "\n",
+    "\n",
+    "text = 'Alice goes down the rabbit hole. Where she would discover a new reality beyond her expectations.'\n",
+    "\n",
+    "nlp = spacy.load(\"en_core_web_sm\")\n",
+    "nlp.add_pipe(\n",
+    "    \"fastcoref\",\n",
+    "    config={\n",
+    "        'model_architecture': 'LingMessCoref', \n",
+    "        'model_path': 'biu-nlp/lingmess-coref', \n",
+    "        'device': 'cpu'}\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/20/2023 22:58:30 - INFO - \t Tokenize 1 inputs...\n",
+      "Map: 100%|██████████| 1/1 [00:00<00:00, 186.89 examples/s]\n",
+      "08/20/2023 22:58:30 - INFO - \t ***** Running Inference on 1 texts *****\n",
+      "Inference: 100%|██████████| 1/1 [00:04<00:00,  4.19s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "doc = nlp(\n",
+    "    text,\n",
+    "    component_cfg={\"fastcoref\": {'resolve_text': True}}\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Alice goes down the rabbit hole. Where Alice would discover a new reality beyond Alice's expectations.\""
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "doc._.resolved_text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/aakash/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "08/24/2023 16:21:09 - INFO - \t missing_keys: []\n",
+      "08/24/2023 16:21:09 - INFO - \t unexpected_keys: []\n",
+      "08/24/2023 16:21:09 - INFO - \t mismatched_keys: []\n",
+      "08/24/2023 16:21:09 - INFO - \t error_msgs: []\n",
+      "08/24/2023 16:21:09 - INFO - \t Model Parameters: 590.0M, Transformer: 434.6M, Coref head: 155.4M\n"
+     ]
+    }
+   ],
+   "source": [
+    "from CoreferenceResolution.FCOREF import get_coref_resolved_text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/24/2023 16:21:46 - INFO - \t Tokenize 1 inputs...\n",
+      "Map: 100%|██████████| 1/1 [00:00<00:00,  2.50 examples/s]\n",
+      "08/24/2023 16:21:47 - INFO - \t ***** Running Inference on 1 texts *****\n",
+      "Inference: 100%|██████████| 1/1 [00:06<00:00,  6.41s/it]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"Aakash is a student. Aakash likes to study Data science. Aakash's knowledge is intermediate in Data science.\""
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = \"Aakash is a student. He likes to study Data science. His knowledge is intermediate in it.\"\n",
+    "get_coref_resolved_text(t)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/24/2023 16:23:31 - INFO - \t Tokenize 1 inputs...\n",
+      "Map: 100%|██████████| 1/1 [00:00<00:00, 54.18 examples/s]\n",
+      "08/24/2023 16:23:31 - INFO - \t ***** Running Inference on 1 texts *****\n",
+      "Inference: 100%|██████████| 1/1 [00:04<00:00,  4.91s/it]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'\\nTendulkar took up cricket at the age of eleven, made Tendulkar\\'s Test match debut on 15 November \\n1989 against Pakistan in Karachi at the age of sixteen, and went on to represent Mumbai \\ndomestically and India internationally for over 24 years.[9] In The same year, halfway through Tendulkar\\'s \\ncareer, Wisden ranked Tendulkar the second-greatest Test batsman of all time, behind Don Bradman, \\nand the second-greatest ODI batsman of all time, behind Viv Richards.[10] The same year, \\nTendulkar was a part of the team that was one of the joint-winners of the 2002 ICC Champions Trophy. \\nLater in Tendulkar\\'s career, Tendulkar was part of the Indian team that won the 2011 Cricket World Cup, \\nTendulkar\\'s first win in six the 2011 Cricket World Cup appearances for India] Tendulkar had previously been named \\n\"Player of the Tournament\" at the 2003 World Cup.\\n'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = \"\"\"\n",
+    "Tendulkar took up cricket at the age of eleven, made his Test match debut on 15 November \n",
+    "1989 against Pakistan in Karachi at the age of sixteen, and went on to represent Mumbai \n",
+    "domestically and India internationally for over 24 years.[9] In 2002, halfway through his \n",
+    "career, Wisden ranked him the second-greatest Test batsman of all time, behind Don Bradman, \n",
+    "and the second-greatest ODI batsman of all time, behind Viv Richards.[10] The same year, \n",
+    "Tendulkar was a part of the team that was one of the joint-winners of the 2002 ICC Champions Trophy. \n",
+    "Later in his career, Tendulkar was part of the Indian team that won the 2011 Cricket World Cup, \n",
+    "his first win in six World Cup appearances for India.[11] He had previously been named \n",
+    "\"Player of the Tournament\" at the 2003 World Cup.\n",
+    "\"\"\"\n",
+    "get_coref_resolved_text(t)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/24/2023 16:26:01 - INFO - \t Tokenize 1 inputs...\n",
+      "Map: 100%|██████████| 1/1 [00:00<00:00, 185.98 examples/s]\n",
+      "08/24/2023 16:26:01 - INFO - \t ***** Running Inference on 1 texts *****\n",
+      "Inference: 100%|██████████| 1/1 [00:04<00:00,  4.06s/it]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"Jack and James are friends. James is a violinist and James's favourite sport is baseball.\""
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = \"Jack and James are friends. He is a violinist and his favourite sport is baseball.\"\n",
+    "get_coref_resolved_text(t)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Data.collector import (\n",
+    "    get_wikiPageWikiLink_entities,\n",
+    "    get_only_wikiPageWikiLink\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "res = get_wikiPageWikiLink_entities(entity=\"<http://dbpedia.org/resource/Berlin_Wall>\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ores = get_only_wikiPageWikiLink(entity=\"<http://dbpedia.org/resource/Berlin_Wall>\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "339"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mThe Kernel crashed while executing code in the the current cell or a previous cell. Please review the code in the cell(s) to identify a possible cause of the failure. Click <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. View Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+     ]
+    }
+   ],
+   "source": [
+    "len(ores)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from allennlp.predictors.predictor import Predictor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "error loading _jsonnet (this is expected on Windows), treating /tmp/tmp_2m1mwj_/config.json as plain json\n"
+     ]
+    },
+    {
+     "ename": "ConfigurationError",
+     "evalue": "coref not in acceptable choices for dataset_reader.type: ['babi', 'conll2003', 'interleaving', 'multitask', 'multitask_shim', 'sequence_tagging', 'sharded', 'text_classification_json']. You should either use the --include-package flag to make sure the correct module is loaded, or use a fully qualified class name in your config file like {\"model\": \"my_module.models.MyModel\"} to have it imported automatically.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mConfigurationError\u001b[0m                        Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_10472/474992419.py\u001b[0m in \u001b[0;36m<cell line: 0>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# model_url = 'https://storage.googleapis.com/allennlp-public-models/coref-spanbert-large-2020.02.27.tar.gz'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mpredictor\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mPredictor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_path\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"./../coref-spanbert-large-2020.02.27.tar.gz\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/allennlp/predictors/predictor.py\u001b[0m in \u001b[0;36mfrom_path\u001b[0;34m(cls, archive_path, predictor_name, cuda_device, dataset_reader_to_load, frozen, import_plugins, overrides, **kwargs)\u001b[0m\n\u001b[1;32m    364\u001b[0m             \u001b[0mplugins\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimport_plugins\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    365\u001b[0m         return Predictor.from_archive(\n\u001b[0;32m--> 366\u001b[0;31m             \u001b[0mload_archive\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marchive_path\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcuda_device\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcuda_device\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverrides\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0moverrides\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    367\u001b[0m             \u001b[0mpredictor_name\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    368\u001b[0m             \u001b[0mdataset_reader_to_load\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdataset_reader_to_load\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/allennlp/models/archival.py\u001b[0m in \u001b[0;36mload_archive\u001b[0;34m(archive_file, cuda_device, overrides, weights_file)\u001b[0m\n\u001b[1;32m    230\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m         \u001b[0;31m# Instantiate model and dataset readers. Use a duplicate of the config, as it will get consumed.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m         dataset_reader, validation_dataset_reader = _load_dataset_readers(\n\u001b[0m\u001b[1;32m    233\u001b[0m             \u001b[0mconfig\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mduplicate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mserialization_dir\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m         )\n",
+      "\u001b[0;32m~/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/allennlp/models/archival.py\u001b[0m in \u001b[0;36m_load_dataset_readers\u001b[0;34m(config, serialization_dir)\u001b[0m\n\u001b[1;32m    266\u001b[0m     )\n\u001b[1;32m    267\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 268\u001b[0;31m     dataset_reader = DatasetReader.from_params(\n\u001b[0m\u001b[1;32m    269\u001b[0m         \u001b[0mdataset_reader_params\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mserialization_dir\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mserialization_dir\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    270\u001b[0m     )\n",
+      "\u001b[0;32m~/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/allennlp/common/from_params.py\u001b[0m in \u001b[0;36mfrom_params\u001b[0;34m(cls, params, constructor_to_call, constructor_to_inspect, **extras)\u001b[0m\n\u001b[1;32m    583\u001b[0m             \u001b[0mas_registrable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcast\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mType\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mRegistrable\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    584\u001b[0m             \u001b[0mdefault_to_first_choice\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mas_registrable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault_implementation\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 585\u001b[0;31m             choice = params.pop_choice(\n\u001b[0m\u001b[1;32m    586\u001b[0m                 \u001b[0;34m\"type\"\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    587\u001b[0m                 \u001b[0mchoices\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mas_registrable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlist_available\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/D/miniconda3/envs/gsoc/lib/python3.11/site-packages/allennlp/common/params.py\u001b[0m in \u001b[0;36mpop_choice\u001b[0;34m(self, key, choices, default_to_first_choice, allow_class_names)\u001b[0m\n\u001b[1;32m    322\u001b[0m                 \u001b[0;34m\"\"\"{\"model\": \"my_module.models.MyModel\"} to have it imported automatically.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    323\u001b[0m             )\n\u001b[0;32m--> 324\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mConfigurationError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    325\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    326\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mConfigurationError\u001b[0m: coref not in acceptable choices for dataset_reader.type: ['babi', 'conll2003', 'interleaving', 'multitask', 'multitask_shim', 'sequence_tagging', 'sharded', 'text_classification_json']. You should either use the --include-package flag to make sure the correct module is loaded, or use a fully qualified class name in your config file like {\"model\": \"my_module.models.MyModel\"} to have it imported automatically."
+     ]
+    }
+   ],
+   "source": [
+    "# model_url = 'https://storage.googleapis.com/allennlp-public-models/coref-spanbert-large-2020.02.27.tar.gz'\n",
+    "predictor = Predictor.from_path(\"./../coref-spanbert-large-2020.02.27.tar.gz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gsoc",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/GSoC23/Data/collector.py
+++ b/GSoC23/Data/collector.py
@@ -36,6 +36,17 @@ def get_text_of_wiki_page(article_name: str):
     return article_name_content
 
 def get_wikiPageWikiLink_entities(entity, sparql_wrapper = sparql):
+    """A function to fetch all entities connected to the given entity
+    by the dbo:wikiPageWikiLink predicate.
+
+    Args:
+        entity (_type_): The source entity, the wiki page we are parsing. 
+        Example --> <http://dbpedia.org/resource/Berlin_Wall>.
+        sparql_wrapper : The SPARQL endpoint. Defaults to sparql.
+
+    Returns: List of entities.
+    """
+
     query = f'''
     PREFIX dbo: <http://dbpedia.org/ontology/>
 
@@ -52,6 +63,16 @@ def get_wikiPageWikiLink_entities(entity, sparql_wrapper = sparql):
 
 
 def get_only_wikiPageWikiLink(entity, sparql_wrapper = sparql):
+    """For a given entity(the current wiki page), returns all entities
+    that are connected with only the dbo:wikiPageWikiLink predicate and no
+    other predicate.
+    Args:
+        entity : The source entity, the current wiki page.
+        Example --> <http://dbpedia.org/resource/Berlin_Wall>.
+        sparql_wrapper : The SPARQL endpoint. Defaults to sparql.
+
+    Returns: List of entities.
+    """
 
     query = f'''
     PREFIX dbo: <http://dbpedia.org/ontology/>

--- a/GSoC23/Data/collector.py
+++ b/GSoC23/Data/collector.py
@@ -3,7 +3,8 @@ import wikipedia
 
 # Create a SPARQLWrapper object with the DBpedia SPARQL endpoint URL
 sparql = SPARQLWrapper("http://dbpedia.org/sparql")
-print('Sparql wrapper created')
+print("Sparql wrapper created")
+
 
 def get_abstract(sparql_wrapper, uri):
     query = f"""
@@ -16,7 +17,8 @@ def get_abstract(sparql_wrapper, uri):
     sparql_wrapper.setQuery(query)
     sparql_wrapper.setReturnFormat(JSON)
     results = sparql_wrapper.query().convert()
-    return results['results']['bindings'][0]['abstract']['value']
+    return results["results"]["bindings"][0]["abstract"]["value"]
+
 
 def get_text_of_wiki_page(article_name: str):
     """Given an article name(need not be exact title of page),
@@ -30,39 +32,44 @@ def get_text_of_wiki_page(article_name: str):
     Returns:
         str: The text of that article.
     """
-    article_name_result = wikipedia.page(wikipedia.search(article_name)[0], auto_suggest=False)
+    article_name_result = wikipedia.page(
+        wikipedia.search(article_name)[0], auto_suggest=False
+    )
     article_name_content = article_name_result.content
     article_name_content.replace("\n", "").replace("\t", "")
     return article_name_content
 
-def get_wikiPageWikiLink_entities(entity, sparql_wrapper = sparql):
+
+def get_wikiPageWikiLink_entities(entity, sparql_wrapper=sparql):
     """A function to fetch all entities connected to the given entity
     by the dbo:wikiPageWikiLink predicate.
 
     Args:
-        entity (_type_): The source entity, the wiki page we are parsing. 
+        entity (_type_): The source entity, the wiki page we are parsing.
         Example --> <http://dbpedia.org/resource/Berlin_Wall>.
         sparql_wrapper : The SPARQL endpoint. Defaults to sparql.
 
     Returns: List of entities.
     """
 
-    query = f'''
+    query = f"""
     PREFIX dbo: <http://dbpedia.org/ontology/>
 
     SELECT ?connected_entities
     WHERE{{
     {entity} dbo:wikiPageWikiLink ?connected_entities .
     }}
-    '''
+    """
     sparql_wrapper.setQuery(query)
     sparql_wrapper.setReturnFormat(JSON)
     results = sparql_wrapper.query().convert()
-    entities = [r['connected_entities']['value'] for r in results['results']['bindings']]
+    entities = [
+        r["connected_entities"]["value"] for r in results["results"]["bindings"]
+    ]
     return entities
 
 
-def get_only_wikiPageWikiLink(entity, sparql_wrapper = sparql):
+def get_only_wikiPageWikiLink(entity, sparql_wrapper=sparql):
     """For a given entity(the current wiki page), returns all entities
     that are connected with only the dbo:wikiPageWikiLink predicate and no
     other predicate.
@@ -74,7 +81,7 @@ def get_only_wikiPageWikiLink(entity, sparql_wrapper = sparql):
     Returns: List of entities.
     """
 
-    query = f'''
+    query = f"""
     PREFIX dbo: <http://dbpedia.org/ontology/>
 
     SELECT ?o
@@ -91,8 +98,8 @@ def get_only_wikiPageWikiLink(entity, sparql_wrapper = sparql):
         FILTER (?p != dbo:wikiPageWikiLink)
       }}
     }}
-    '''
+    """
     sparql_wrapper.setQuery(query)
     sparql_wrapper.setReturnFormat(JSON)
     results = sparql_wrapper.query().convert()
-    return results['results']['bindings']
+    return results["results"]["bindings"]

--- a/GSoC23/EntityLinking/el_utils.py
+++ b/GSoC23/EntityLinking/el_utils.py
@@ -1,18 +1,26 @@
 import re
 import pandas as pd
 
+
 def annotate_sentence(sentence, mention):
     match = re.search(mention.lower(), sentence.lower())
     start, end = match.span()
-    sentence = sentence[:start] + " [START_ENT] " + sentence[start:end] + " [END_ENT] " + sentence[end:]
+    sentence = (
+        sentence[:start]
+        + " [START_ENT] "
+        + sentence[start:end]
+        + " [END_ENT] "
+        + sentence[end:]
+    )
     return sentence
+
 
 def get_majority_vote(candidate_list):
     """Perform majority vote over a list of candidate entities
     based on frequency.
 
-    Initially, we are using frequency to do the voting. 
-    But later on, we can also do a weighted voting, 
+    Initially, we are using frequency to do the voting.
+    But later on, we can also do a weighted voting,
     by weighing each candidate based on the method which returned it,
     thereby giving more importance to more accurate methods.
 
@@ -25,11 +33,12 @@ def get_majority_vote(candidate_list):
     candidate_entity = max(set(candidate_list), key=candidate_list.count)
     return candidate_entity
 
+
 def convert_sentence_for_genre_model(sentence, entity):
     """A function to provide annotated form of the sentence.
     The sentence we provide here should first be passed through
     the NER system to get all entities in it. Then, with each entity
-    individually, we pass it to this function. And we pass the result of 
+    individually, we pass it to this function. And we pass the result of
     this function to the GENRE entity disambiguation model.
 
     Args:
@@ -37,44 +46,51 @@ def convert_sentence_for_genre_model(sentence, entity):
         entity (_type_): A dictionary containing the entity text
         entity span and other such info
     """
-    start = entity['start']
-    end = entity['end']
+    start = entity["start"]
+    end = entity["end"]
 
-    # We need to add [START_ENT] tag before the entity and [END_ENT] tag 
+    # We need to add [START_ENT] tag before the entity and [END_ENT] tag
     # after the entity we want to link and disambiguate
     result_sentence = sentence[:start]
-    result_sentence+= '[START_ENT] '
-    result_sentence+= sentence[start:end]
-    result_sentence+= ' [END_ENT] '
-    result_sentence+= sentence[end:]
+    result_sentence += "[START_ENT] "
+    result_sentence += sentence[start:end]
+    result_sentence += " [END_ENT] "
+    result_sentence += sentence[end:]
     result_sentence = result_sentence.strip()
     return result_sentence
+
 
 def calculate_redirect(source, client):
     result = client.get(source)
     if result is None:
-        return source if type(source) is str else source.decode('utf-8')
+        return source if type(source) is str else source.decode("utf-8")
     return calculate_redirect(result, client)
+
 
 def query(surface_form, client):
     raw = client.hgetall(surface_form)
     if len(raw) == 0:
-        return pd.DataFrame(columns=['entity', 'support', 'score'])
-    
+        return pd.DataFrame(columns=["entity", "support", "score"])
+
     out = []
     for label, score in raw.items():
-        out.append({'entity': label.decode('utf-8'), 'support': int(score)})
+        out.append({"entity": label.decode("utf-8"), "support": int(score)})
     df_all = pd.DataFrame(out)
-    df_all['score'] = df_all['support'] / df_all['support'].max()
-    
-    return df_all.sort_values(by='score', ascending=False).reset_index(drop=True)
+    df_all["score"] = df_all["support"] / df_all["support"].max()
+
+    return df_all.sort_values(by="score", ascending=False).reset_index(drop=True)
+
 
 def lookup(term, top_k=5, thr=0.01, redis_client_forms=None, redis_client_redir=None):
     df_temp = query(term, redis_client_forms)
-#     display(df_temp)
-    df_temp['entity'] = df_temp['entity'].apply(lambda x: calculate_redirect(x, redis_client_redir))
+    #     display(df_temp)
+    df_temp["entity"] = df_temp["entity"].apply(
+        lambda x: calculate_redirect(x, redis_client_redir)
+    )
     if len(df_temp) == 0:
-        return pd.DataFrame(columns=['entity', 'support', 'score'])
-    df_final = df_temp.groupby('entity').sum()[['support']]
-    df_final['score'] = df_final['support'] / df_final['support'].max()
-    return df_final[df_final['score'] >= thr].sort_values(by='score', ascending=False)[:top_k]
+        return pd.DataFrame(columns=["entity", "support", "score"])
+    df_final = df_temp.groupby("entity").sum()[["support"]]
+    df_final["score"] = df_final["support"] / df_final["support"].max()
+    return df_final[df_final["score"] >= thr].sort_values(by="score", ascending=False)[
+        :top_k
+    ]

--- a/GSoC23/EntityLinking/methods.py
+++ b/GSoC23/EntityLinking/methods.py
@@ -115,3 +115,33 @@ def EL_GENRE(annotated_sentences, model, tokenizer):
     # These entites are in the form of wikipedia page titles. Need to
     # add the https://dbpedia/resource to each of them as postprocessing step
     return entites
+
+def EL_GENRE_pipeline(pipe, annotated_sentences):
+    """A method to perform entity linking for entity-mentions annotated
+    in sentences using the GENRE model with transformers pipeline. 
+    Works faster than the approach without pipeline.
+
+    Args:
+        pipe (transformers.pipelines.text2text_generation.Text2TextGenerationPipeline): The transformers pipeline object.
+        annotated_sentences (list): List of annotated sentences.
+
+    Returns:
+        list: The list of entities.
+
+    Example:
+        ans = [annotate_sentence(s,m) for s,m in [
+        ("Messi plays for Argentina", "Messi"),
+        ("Messi plays for Argentina", "Argentina"),
+        ("India is in Asia", "India")
+        ]]
+
+        genre_pipe = genre_pipe = pipeline(
+            model="facebook/genre-linking-blink", 
+            tokenizer="facebook/genre-linking-blink")
+        pipe_results = genre_pipe(ans)
+
+        entities = [e['generated_text'] for e in res]
+    """
+    pipe_results = pipe(annotated_sentences)
+    entities = [e['generated_text'] for e in pipe_results]
+    return entities

--- a/GSoC23/EntityLinking/methods.py
+++ b/GSoC23/EntityLinking/methods.py
@@ -1,6 +1,4 @@
 import requests
-import spacy_dbpedia_spotlight
-import spacy
 import pandas as pd
 import redis
 

--- a/GSoC23/NER/methods.py
+++ b/GSoC23/NER/methods.py
@@ -1,14 +1,11 @@
 import spacy
 from transformers import pipeline
 
-stop = [
-    "the", "is", "in",
-    "for", "where", "when",
-    "to", "at"
-]
+stop = ["the", "is", "in", "for", "where", "when", "to", "at"]
+
 
 def spacy_ner(language: spacy.lang.en.English, text: str):
-    """Performs NER using the spacy model(language) specified. 
+    """Performs NER using the spacy model(language) specified.
 
     Args:
         language (spacy.lang.en.English): The spacy English model to use.
@@ -22,7 +19,7 @@ def spacy_ner(language: spacy.lang.en.English, text: str):
     entities = []
     for ent in result.ents:
         d = {}
-        d['entity_group']=ent.label_
+        d["entity_group"] = ent.label_
 
         # check for stop-words
         text = ent.text
@@ -31,12 +28,13 @@ def spacy_ner(language: spacy.lang.en.English, text: str):
                 # print(type(ent.text))
                 # ent.text = ent.text.replace(st,"")
                 text = text.replace(st, "")
-                
-        d['word']=text
-        d['start']=ent.start_char
-        d['end']=ent.end_char
+
+        d["word"] = text
+        d["start"] = ent.start_char
+        d["end"] = ent.end_char
         entities.append(d)
     return entities
+
 
 def hf_transformer_ner(model, tokenizer, text):
     """Given a text, model and its tokenizer(from huggingface), perform

--- a/GSoC23/Readme.md
+++ b/GSoC23/Readme.md
@@ -11,10 +11,12 @@
 All directories contain a `notebooks` directory which has notebooks with exploration/experimentation code for the models and methods used. 
 ```
 📦GSoC23
+ ┣ 📂CoreferenceResolution
  ┣ 📂Data
  ┣ 📂EntityLinking
  ┣ 📂NER
  ┣ 📂RelationExtraction
+ ┣ 📂Validation
 ```
 
 ### Installations 
@@ -39,7 +41,8 @@ use `spacy.download('en_core_trf')`
 graph TD
     wiki_page[Wikipedia Page] --Extract plain text--> pure_text[Pure text]
 
-    pure_text-->rebel(REBEL)
+    pure_text-->coref_resolved_text[Coref Resolved Text]
+    coref_resolved_text-->rebel(REBEL)
     rebel--as text-->entities[Entities]
     rebel--as text-->relations[Relations]
     

--- a/GSoC23/Readme.md
+++ b/GSoC23/Readme.md
@@ -42,14 +42,15 @@ graph TD
     wiki_page[Wikipedia Page] --Extract plain text--> pure_text[Pure text]
 
     pure_text--coreference resolution-->coref_resolved_text[Coreference Resolved Text]
-    coref_resolved_text-->rebel(REBEL)
+    coref_resolved_text-->sentences[Sentences]
+    sentences-->rebel(REBEL)
     rebel--as text-->entities[Entities]
     rebel--as text-->relations[Relations]
     
     relations--get embedding-->vector_similarity(Vector similarity with label embeddings);
     vector_similarity-->predicate_uris[Predicate URIs]
 
-    coref_resolved_text-->annotation_for_genre(Annotate entities in text)
+    sentences-->annotation_for_genre(Annotate entities in text)
 
     entities-->annotation_for_genre
 

--- a/GSoC23/Readme.md
+++ b/GSoC23/Readme.md
@@ -43,14 +43,14 @@ graph TD
 
     pure_text--coreference resolution-->coref_resolved_text[Coreference Resolved Text]
     coref_resolved_text-->sentences[Sentences]
-    sentences-->rebel(REBEL)
+    sentences--sentence_i-->rebel(REBEL)
     rebel--as text-->entities[Entities]
     rebel--as text-->relations[Relations]
     
     relations--get embedding-->vector_similarity(Vector similarity with label embeddings);
     vector_similarity-->predicate_uris[Predicate URIs]
 
-    sentences-->annotation_for_genre(Annotate entities in text)
+    sentences--sentence_i-->annotation_for_genre(Annotate entities in text)
 
     entities-->annotation_for_genre
 

--- a/GSoC23/Readme.md
+++ b/GSoC23/Readme.md
@@ -41,7 +41,7 @@ use `spacy.download('en_core_trf')`
 graph TD
     wiki_page[Wikipedia Page] --Extract plain text--> pure_text[Pure text]
 
-    pure_text-->coref_resolved_text[Coref Resolved Text]
+    pure_text--coreference resolution-->coref_resolved_text[Coreference Resolved Text]
     coref_resolved_text-->rebel(REBEL)
     rebel--as text-->entities[Entities]
     rebel--as text-->relations[Relations]
@@ -49,7 +49,7 @@ graph TD
     relations--get embedding-->vector_similarity(Vector similarity with label embeddings);
     vector_similarity-->predicate_uris[Predicate URIs]
 
-    pure_text-->annotation_for_genre(Annotate entities in text)
+    coref_resolved_text-->annotation_for_genre(Annotate entities in text)
 
     entities-->annotation_for_genre
 

--- a/GSoC23/RelationExtraction/config.json
+++ b/GSoC23/RelationExtraction/config.json
@@ -1,0 +1,12 @@
+{
+    "file_paths": {
+        "label_embeddings_file": "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/dbpedia-ontology.vectors",
+        "tbox_pickle_file": "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/tbox.pkl",
+        "labels_pickle_file": "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/labels.pkl"
+    },
+    "model_names": {
+        "encoder_model": "paraphrase-MiniLM-L6-v2",
+        "genre_tokenizer": "facebook/genre-linking-blink",
+        "genre_model": "facebook/genre-linking-blink"
+    }
+}

--- a/GSoC23/RelationExtraction/encoding_utils.py
+++ b/GSoC23/RelationExtraction/encoding_utils.py
@@ -1,15 +1,15 @@
 from collections import defaultdict
 from SPARQLWrapper import SPARQLWrapper, JSON
 
-NS_RESOURCE = 'http://dbpedia.org/resource/'
+NS_RESOURCE = "http://dbpedia.org/resource/"
 NS_RESOURCE_LEN = len(NS_RESOURCE)
 
-NS_ONTOLOGY = 'http://dbpedia.org/ontology/'
+NS_ONTOLOGY = "http://dbpedia.org/ontology/"
 NS_ONTOLOGY_LEN = len(NS_ONTOLOGY)
 
 
-def retrieve_tbox(lang='en', offset=0):
-    sparql = SPARQLWrapper('http://dbpedia.org/sparql')
+def retrieve_tbox(lang="en", offset=0):
+    sparql = SPARQLWrapper("http://dbpedia.org/sparql")
     query = f"""
     SELECT ?uri ?label ?domain ?range {{
       ?uri a ?type ; rdfs:label ?label; rdfs:domain ?domain ; rdfs:range ?range.
@@ -20,28 +20,31 @@ def retrieve_tbox(lang='en', offset=0):
     sparql.setQuery(query)
     sparql.setReturnFormat(JSON)
     results = sparql.query().convert()
-    
+
     tbox = {}
     uri_domain_range_dict = defaultdict(lambda: {})
-    for result in results['results']['bindings']:
-        uri = result['uri']['value']
-        label = result['label']['value']
+    for result in results["results"]["bindings"]:
+        uri = result["uri"]["value"]
+        label = result["label"]["value"]
         if label not in tbox:
             tbox[label] = set()
         tbox[label].add(uri)
 
-        domain_ = result['domain']['value']
-        range_ = result['range']['value']
-        uri_domain_range_dict[uri]['domain'] = domain_
-        uri_domain_range_dict[uri]['range'] = range_
+        domain_ = result["domain"]["value"]
+        range_ = result["range"]["value"]
+        uri_domain_range_dict[uri]["domain"] = domain_
+        uri_domain_range_dict[uri]["range"] = range_
     return tbox, uri_domain_range_dict
+
 
 def get_labels_tbox_and_domain_range():
     offset = 0
     tbox = {}
     uri_domain_and_range = {}
     while True:
-        tbox_chunk, uri_domain_and_range_dict_chunk = retrieve_tbox(lang='en', offset=offset)
+        tbox_chunk, uri_domain_and_range_dict_chunk = retrieve_tbox(
+            lang="en", offset=offset
+        )
         if len(tbox_chunk) == 0:
             break
         offset += 10000
@@ -49,17 +52,26 @@ def get_labels_tbox_and_domain_range():
             if k not in tbox:
                 tbox[k] = set()
             tbox[k] = tbox[k].union(v)
-        for k,v in uri_domain_and_range_dict_chunk.items():
-            uri_domain_and_range[k]=v
-    labels = [l.replace('\n', ' ') for l in tbox]
+        for k, v in uri_domain_and_range_dict_chunk.items():
+            uri_domain_and_range[k] = v
+    labels = [l.replace("\n", " ") for l in tbox]
     return labels, tbox, uri_domain_and_range
 
+
 def to_uri(label, tbox):
-    return list(filter(lambda x: 'A' <= x[NS_ONTOLOGY_LEN : NS_ONTOLOGY_LEN+1] <= 'z', tbox[label]))
+    return list(
+        filter(
+            lambda x: "A" <= x[NS_ONTOLOGY_LEN : NS_ONTOLOGY_LEN + 1] <= "z",
+            tbox[label],
+        )
+    )
+
 
 def write_embeddings_to_file(embeddings, labels, filename):
-    with open(filename, 'w', encoding='utf-8') as f_out:
+    with open(filename, "w", encoding="utf-8") as f_out:
         f_out.write(f"{len(labels)} {len(embeddings[0])}\n")
         for label, embedding in zip(labels, embeddings):
-            f_out.write(f"{label.replace(' ', '_')} {' '.join([str(x) for x in embedding])}\n")
+            f_out.write(
+                f"{label.replace(' ', '_')} {' '.join([str(x) for x in embedding])}\n"
+            )
     print("Embeddings written to file successfully")

--- a/GSoC23/RelationExtraction/methods.py
+++ b/GSoC23/RelationExtraction/methods.py
@@ -1,22 +1,23 @@
 from GSoC23.RelationExtraction.rebel import extract_relations_rebel
 from GSoC23.RelationExtraction.re_utils import get_triple_from_triple
 
+
 def get_triples_from_sentence_using_rebel(sentence, rebel_model, rebel_tokenizer):
-    sent_triples =  extract_relations_rebel(rebel_model, rebel_tokenizer, text=sentence)
+    sent_triples = extract_relations_rebel(rebel_model, rebel_tokenizer, text=sentence)
     triples = []
-    
+
     for i in range(len(sent_triples)):
         subject, relation, objct, score = sent_triples.iloc[i].values
         triple = get_triple_from_triple(subject, relation, objct, sentence)
         triples.append(
-        {
-            "subject":subject,
-            "predicate":relation,
-            "object":objct,
-            "subject_URI": triple[0],
-            "predicate_URI":triple[1],
-            "object_URI":triple[2],
-            "relation_confidence_score":score,
-        }
+            {
+                "subject": subject,
+                "predicate": relation,
+                "object": objct,
+                "subject_URI": triple[0],
+                "predicate_URI": triple[1],
+                "object_URI": triple[2],
+                "relation_confidence_score": score,
+            }
         )
     return triples

--- a/GSoC23/RelationExtraction/re_utils.py
+++ b/GSoC23/RelationExtraction/re_utils.py
@@ -3,36 +3,49 @@ import pickle
 import logging
 from GSoC23.EntityLinking.methods import EL_GENRE
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-from GSoC23.RelationExtraction.relation_similarity import load_key_vector_model_from_file
-from GSoC23.RelationExtraction.text_encoding_models import get_sentence_transformer_model
+from GSoC23.RelationExtraction.relation_similarity import (
+    load_key_vector_model_from_file,
+)
+from GSoC23.RelationExtraction.text_encoding_models import (
+    get_sentence_transformer_model,
+)
 from GSoC23.RelationExtraction.relation_similarity import ontosim_search
 from GSoC23.EntityLinking.el_utils import annotate_sentence
 
-with open("config.json",'r') as config_file:
+with open("config.json", "r") as config_file:
     config = json.load(config_file)
 
-label_embeddings_file = config['file_paths']['label_embeddings_file']
+label_embeddings_file = config["file_paths"]["label_embeddings_file"]
 gensim_model = load_key_vector_model_from_file(label_embeddings_file)
 
-tbox_pickle_file = config['file_paths']['tbox_pickle_file']
-labels_pickle_file = config['file_paths']['labels_pickle_file']
+tbox_pickle_file = config["file_paths"]["tbox_pickle_file"]
+labels_pickle_file = config["file_paths"]["labels_pickle_file"]
+
 
 def get_pickle_object(file):
     """This function can be used to load the labels.pkl
     and tbox.pkl files.
     """
-    with open(file,"rb") as f:
+    with open(file, "rb") as f:
         return pickle.load(f)
-    
-labels=get_pickle_object(labels_pickle_file)
-tbox=get_pickle_object(tbox_pickle_file)
 
-encoder_model = get_sentence_transformer_model(model_name=config['model_names']['encoder_model'])
+
+labels = get_pickle_object(labels_pickle_file)
+tbox = get_pickle_object(tbox_pickle_file)
+
+encoder_model = get_sentence_transformer_model(
+    model_name=config["model_names"]["encoder_model"]
+)
 logging.info("Encoder model loaded")
 
-genre_tokenizer = AutoTokenizer.from_pretrained(config['model_names']['genre_tokenizer'])
-genre_model = AutoModelForSeq2SeqLM.from_pretrained(config['model_names']['genre_model']).eval()
+genre_tokenizer = AutoTokenizer.from_pretrained(
+    config["model_names"]["genre_tokenizer"]
+)
+genre_model = AutoModelForSeq2SeqLM.from_pretrained(
+    config["model_names"]["genre_model"]
+).eval()
 logging.info("GENRE model loaded")
+
 
 def get_triple_from_triple(sub, relation, obj, sentence):
     """Give subject, relation, object in natural language form,
@@ -46,18 +59,21 @@ def get_triple_from_triple(sub, relation, obj, sentence):
     Returns:
         tuple: A tuple of entity and predicate URIs
     """
-    
+
     subject_entity = EL_GENRE(
-        annotate_sentence(sentence, sub), genre_model, genre_tokenizer)[0]
-    subject_entity = "https://dbpedia.org/resource/"+"_".join(subject_entity.split())
-    
+        annotate_sentence(sentence, sub), genre_model, genre_tokenizer
+    )[0]
+    subject_entity = "https://dbpedia.org/resource/" + "_".join(subject_entity.split())
+
     object_entity = EL_GENRE(
-        annotate_sentence(sentence, obj), genre_model, genre_tokenizer)[0]
-    object_entity = "https://dbpedia.org/resource/"+"_".join(object_entity.split())
-    
-    predicates, label, score = ontosim_search(
-        relation, gensim_model, encoder_model, tbox).iloc[0].values
-    
+        annotate_sentence(sentence, obj), genre_model, genre_tokenizer
+    )[0]
+    object_entity = "https://dbpedia.org/resource/" + "_".join(object_entity.split())
+
+    predicates, label, score = (
+        ontosim_search(relation, gensim_model, encoder_model, tbox).iloc[0].values
+    )
+
     predicate = None
     for p in predicates:
         if p.split("/")[-1][0].islower():
@@ -65,4 +81,3 @@ def get_triple_from_triple(sub, relation, obj, sentence):
             break
     # can also return this - (subject_entity, (predicate, score), object_entity)
     return (subject_entity, predicate, object_entity)
-

--- a/GSoC23/RelationExtraction/re_utils.py
+++ b/GSoC23/RelationExtraction/re_utils.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 import logging
 from GSoC23.EntityLinking.methods import EL_GENRE
@@ -7,11 +8,14 @@ from GSoC23.RelationExtraction.text_encoding_models import get_sentence_transfor
 from GSoC23.RelationExtraction.relation_similarity import ontosim_search
 from GSoC23.EntityLinking.el_utils import annotate_sentence
 
-label_embeddings_file = "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/dbpedia-ontology.vectors"
+with open("config.json",'r') as config_file:
+    config = json.load(config_file)
+
+label_embeddings_file = config['file_paths']['label_embeddings_file']
 gensim_model = load_key_vector_model_from_file(label_embeddings_file)
 
-tbox_pickle_file = "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/tbox.pkl"
-labels_pickle_file = "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/labels.pkl"
+tbox_pickle_file = config['file_paths']['tbox_pickle_file']
+labels_pickle_file = config['file_paths']['labels_pickle_file']
 
 def get_pickle_object(file):
     """This function can be used to load the labels.pkl
@@ -23,11 +27,11 @@ def get_pickle_object(file):
 labels=get_pickle_object(labels_pickle_file)
 tbox=get_pickle_object(tbox_pickle_file)
 
-encoder_model = get_sentence_transformer_model(model_name="paraphrase-MiniLM-L6-v2")
+encoder_model = get_sentence_transformer_model(model_name=config['model_names']['encoder_model'])
 logging.info("Encoder model loaded")
 
-genre_tokenizer = AutoTokenizer.from_pretrained("facebook/genre-linking-blink")
-genre_model = AutoModelForSeq2SeqLM.from_pretrained("facebook/genre-linking-blink").eval()
+genre_tokenizer = AutoTokenizer.from_pretrained(config['model_names']['genre_tokenizer'])
+genre_model = AutoModelForSeq2SeqLM.from_pretrained(config['model_names']['genre_model']).eval()
 logging.info("GENRE model loaded")
 
 def get_triple_from_triple(sub, relation, obj, sentence):

--- a/GSoC23/RelationExtraction/re_utils.py
+++ b/GSoC23/RelationExtraction/re_utils.py
@@ -1,4 +1,5 @@
 import pickle
+import logging
 from GSoC23.EntityLinking.methods import EL_GENRE
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from GSoC23.RelationExtraction.relation_similarity import load_key_vector_model_from_file
@@ -6,11 +7,11 @@ from GSoC23.RelationExtraction.text_encoding_models import get_sentence_transfor
 from GSoC23.RelationExtraction.relation_similarity import ontosim_search
 from GSoC23.EntityLinking.el_utils import annotate_sentence
 
-label_embeddings_file = "./dbpedia-ontology.vectors"
+label_embeddings_file = "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/dbpedia-ontology.vectors"
 gensim_model = load_key_vector_model_from_file(label_embeddings_file)
 
-tbox_pickle_file = "./tbox.pkl"
-labels_pickle_file = "./labels.pkl"
+tbox_pickle_file = "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/tbox.pkl"
+labels_pickle_file = "/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/RelationExtraction/labels.pkl"
 
 def get_pickle_object(file):
     """This function can be used to load the labels.pkl
@@ -23,13 +24,15 @@ labels=get_pickle_object(labels_pickle_file)
 tbox=get_pickle_object(tbox_pickle_file)
 
 encoder_model = get_sentence_transformer_model(model_name="paraphrase-MiniLM-L6-v2")
+logging.info("Encoder model loaded")
+
 genre_tokenizer = AutoTokenizer.from_pretrained("facebook/genre-linking-blink")
 genre_model = AutoModelForSeq2SeqLM.from_pretrained("facebook/genre-linking-blink").eval()
+logging.info("GENRE model loaded")
 
 def get_triple_from_triple(sub, relation, obj, sentence):
     """Give subject, relation, object in natural language form,
     return the corressponding Dbpedia URIs for them.
-
     Args:
         sub (str): Subject
         relation (str): Relation

--- a/GSoC23/RelationExtraction/relation_similarity.py
+++ b/GSoC23/RelationExtraction/relation_similarity.py
@@ -2,28 +2,32 @@ import pandas as pd
 from gensim.models import KeyedVectors
 from RelationExtraction.encoding_utils import to_uri
 
+
 def ontosim_search(term, key_vector_model, encoder_model, tbox):
-    """Given a natural language relation, return top 5 most 
+    """Given a natural language relation, return top 5 most
     appropriate dbpedia predicates for it.
 
     Args:
         term : The relation, in natural language.
-        key_vector_model : The Gensim KeyedVectors model. 
+        key_vector_model : The Gensim KeyedVectors model.
         It is like an embedding table for words.
         encoder_model : The encoder model used to encode text to vectors.
-        tbox : A dictionary of labels (of predicates) with a set of 
+        tbox : A dictionary of labels (of predicates) with a set of
         predicates with that label as values.
 
     Returns:
     A dataframe.
     """
-    result = key_vector_model.most_similar(positive=encoder_model.encode([term]), topn=5)
+    result = key_vector_model.most_similar(
+        positive=encoder_model.encode([term]), topn=5
+    )
     out = []
     for label, score in result:
-        out.append({'label': label.replace('_', ' '), 'score': score})
+        out.append({"label": label.replace("_", " "), "score": score})
     df = pd.DataFrame(out)
-    df.insert(0, 'URIs', df['label'].map(lambda x: to_uri(x, tbox=tbox)))
+    df.insert(0, "URIs", df["label"].map(lambda x: to_uri(x, tbox=tbox)))
     return df
+
 
 def load_key_vector_model_from_file(filepath):
     model = KeyedVectors.load_word2vec_format(filepath, binary=False)

--- a/GSoC23/RelationExtraction/text_encoding_models.py
+++ b/GSoC23/RelationExtraction/text_encoding_models.py
@@ -1,9 +1,12 @@
 from sentence_transformers import SentenceTransformer
-model = SentenceTransformer('paraphrase-MiniLM-L6-v2')
+
+model = SentenceTransformer("paraphrase-MiniLM-L6-v2")
+
 
 def get_sentence_transformer_model(model_name):
     model = SentenceTransformer(model_name_or_path=model_name)
     return model
+
 
 def get_embeddings(labels, sent_tran_model):
     embeddings = sent_tran_model.encode(labels)

--- a/GSoC23/end-2-end-demo.py
+++ b/GSoC23/end-2-end-demo.py
@@ -1,17 +1,18 @@
-#----------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------
 # This file is the initial version of using the end-2-end framework.
 # This is subject to a lot of changes and optimizations.
 # WARNING - Running this file on large texts may result in lot of RAM and time
 # consumption. Though I have shown with wikipedia text, please consider
 # changing to some smaller text(around 5-10 lines) to see quick results.
 # We are working to make this more efficient and fast.
-#----------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------
 import pandas as pd
 from nltk import sent_tokenize
 from GSoC23.Data.collector import get_text_of_wiki_page
 from GSoC23.RelationExtraction.methods import get_triples_from_sentence_using_rebel
 
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
 tokenizer = AutoTokenizer.from_pretrained("Babelscape/rebel-large")
 model = AutoModelForSeq2SeqLM.from_pretrained("Babelscape/rebel-large")
 


### PR DESCRIPTION
**Author**: Aakash Thatte

**Description**: This PR adds code for coreference resolution using F-COREF, adds some code cleanup stuff like removing redundant packages, imports etc. And it also adds black formatting. Along with this, there are some new functions (SPARQL queries) to fetch entities having `dbo:wikiPageWikiLink` predicate with the current entity/wiki page.

**Scope**: Adds new directory for coreference resolution. Modifies some previous files to clean them.

**Impact**: With coreference resolution, we will be able to extract more relations as the mentions get disambiguated.
