### PR TITLE
(GSoC) - Add command line utility to use the Neural Extraction Framework

### DIFF
--- a/GSoC23/Readme.md
+++ b/GSoC23/Readme.md
@@ -48,6 +48,11 @@ Or to run on a text file,
 python end-2-end-use.py --text_filepath "e2e.txt" --v 0 --save_filename "usage_from_file.csv"
 ```
 
+### Example of using the command line utility:
+
+https://github.com/dbpedia/neural-extraction-framework/assets/84656834/306dc5ae-ff43-404c-bac3-5f77a6ffd3a9
+
+
 ### Project workflow
 ```mermaid
 graph TD

--- a/GSoC23/Readme.md
+++ b/GSoC23/Readme.md
@@ -39,11 +39,15 @@ python models.py
 ```
 
 ### Run from command line
-We also provide an option to run the code from the command line with possibilities to only run it on a single sentence, or a text or a wikipedia page.
+We also provide an option to run the code from the command line with possibilities to only run it on a single sentence, or a text file or a wikipedia page.
 ```
 python end-2-end-use.py --text "Washinton is a city in the USA. Barack Obama was the president of the United states of America." --v 0 --save_filename "usage.csv"
 ```
-![Video](/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/NEF_short.mp4)
+Or to run on a text file,
+```
+python end-2-end-use.py --text_filepath "e2e.txt" --v 0 --save_filename "usage_from_file.csv"
+```
+
 ### Project workflow
 ```mermaid
 graph TD

--- a/GSoC23/Readme.md
+++ b/GSoC23/Readme.md
@@ -38,6 +38,12 @@ For downloading all models(from spacy, huggingface transformers etc), use the co
 python models.py
 ```
 
+### Run from command line
+We also provide an option to run the code from the command line with possibilities to only run it on a single sentence, or a text or a wikipedia page.
+```
+python end-2-end-use.py --text "Washinton is a city in the USA. Barack Obama was the president of the United states of America." --v 0 --save_filename "usage.csv"
+```
+![Video](/home/aakash/D/College/GSoC/neural-extraction-framework/GSoC23/NEF_short.mp4)
 ### Project workflow
 ```mermaid
 graph TD

--- a/GSoC23/end-2-end-use.py
+++ b/GSoC23/end-2-end-use.py
@@ -26,6 +26,8 @@ parser.add_argument("--wikipage", default=None,
 parser.add_argument("--save_filename", default=None, 
                     help="The file name of the csv of triples, if this is specified, the file will be saved, else not")
 parser.add_argument("--v", default=0, help="If set to 1, print the triples dataframe")
+parser.add_argument("--text_filepath", default="", 
+                    help="The text file on which the user wants to run triple extraction")
 args = parser.parse_args()
 
 tokenizer = AutoTokenizer.from_pretrained("Babelscape/rebel-large")
@@ -40,7 +42,11 @@ elif args.text:
 elif args.wikipage:
     article_text = get_text_of_wiki_page(args.wikipage)
     sentences = sent_tokenize(article_text)
-
+elif args.text_filepath:
+    with open(args.text_filepath, "r") as f:
+        print("Reading text from file...")
+        text = f.read()
+        sentences = sent_tokenize(text)
 
 triples = []
 

--- a/GSoC23/end-2-end-use.py
+++ b/GSoC23/end-2-end-use.py
@@ -1,0 +1,61 @@
+# ----------------------------------------------------------------------------------
+# This file is the initial version of using the end-2-end framework.
+# This is subject to a lot of changes and optimizations.
+# WARNING - Running this file on large texts may result in lot of RAM consumption.
+# We are working to make this more efficient and fast.
+# ----------------------------------------------------------------------------------
+import sys
+sys.path.append("/home/aakash/D/College/GSoC/neural-extraction-framework/")
+import tqdm
+import pandas as pd
+from nltk import sent_tokenize
+from GSoC23.Data.collector import get_text_of_wiki_page
+from GSoC23.RelationExtraction.methods import get_triples_from_sentence_using_rebel
+
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+import argparse
+
+parser = argparse.ArgumentParser(description='An end-2-end utility program')
+parser.add_argument("--sentence", default=None, 
+                    help="The sentence on which the user wants to run triple extraction")
+parser.add_argument("--text", default="", 
+                    help="The text on which the user wants to run triple extraction")
+parser.add_argument("--wikipage", default=None, 
+                    help="The title of wikipedia page on which to perform relation extraction")
+parser.add_argument("--save_filename", default=None, 
+                    help="The file name of the csv of triples, if this is specified, the file will be saved, else not")
+parser.add_argument("--v", default=0, help="If set to 1, print the triples dataframe")
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained("Babelscape/rebel-large")
+model = AutoModelForSeq2SeqLM.from_pretrained("Babelscape/rebel-large")
+print("Tokenizer and model loaded")
+
+sentences = None
+if args.sentence:
+    sentences = sent_tokenize(args.sentence)
+elif args.text:
+    sentences = sent_tokenize(args.text)
+elif args.wikipage:
+    article_text = get_text_of_wiki_page(args.wikipage)
+    sentences = sent_tokenize(article_text)
+
+
+triples = []
+
+print("Extracting triples...")
+for sentence in tqdm.tqdm(sentences):
+    sentence_triples = get_triples_from_sentence_using_rebel(sentence, model, tokenizer)
+    for sent_trip in sentence_triples:
+        triples.append(sent_trip)
+print("Done")
+
+triples_dataframe = pd.DataFrame(data=triples)
+
+if args.save_filename:
+    triples_dataframe.to_csv(args.save_filename)
+    print("Triples saved to file")
+
+if int(args.v)==1:
+    print(triples_dataframe)


### PR DESCRIPTION
**Author**: Aakash Thatte
**Description**: This PR adds a command line utility to use the neural extraction framework end-2-end. The user can now provide their own sentences, or text files or a wikipedia page title to perform triple extraction on them and optionally save the extracted triples to a csv file, all controlled through command line arguments. 

**Impact**: This adds usability to the project without any code changes to the user.