### PR TITLE
Updated requirements, download script

### DIFF
--- a/GSoC24_H/models/download_models.sh
+++ b/GSoC24_H/models/download_models.sh
@@ -1,13 +1,16 @@
 # Coref
-wget "https://drive.google.com/file/d/1ScVz_o4V3G7watezLriCC0vU5gT7FO7q/view"
-tar tar -xzvf wl_coref_transmucores.tar.gz -C ./coref_model 
+gdown 1ScVz_o4V3G7watezLriCC0vU5gT7FO7q -O wl_coref_transmucores.tar.gz 
+tar -xzvf wl_coref_transmucores.tar.gz -C ./coref_model
+# rm wl_coref_transmucores.tar.gz # remove the tar.gz file after extraction
 
 # RE
-wget "https://drive.usercontent.google.com/u/0/uc?id\u003d1UqOUdeK96m6EabI-cg2EeBz6p3IwrPZ6\u0026export\u003ddownload"
-tar tar -xzvf files_indie.tar.gz -C ./RE_model
+gdown 1UqOUdeK96m6EabI-cg2EeBz6p3IwrPZ6 -O files_indie.tar.gz
+tar -xzvf files_indie.tar.gz -C ./RE_model
+# rm files_indie.tar.gz # remove the tar.gz file after extraction
 
 # EL
 wget "https://dl.fbaipublicfiles.com/GENRE/fairseq_multilingual_entity_disambiguation.tar.gz"
-tar tar -xzvf fairseq_multilingual_entity_disambiguation.tar.gz -C ./EL_model
+tar -xzvf fairseq_multilingual_entity_disambiguation.tar.gz -C ./EL_model
 wget -P ./EL_model "http://dl.fbaipublicfiles.com/GENRE/titles_lang_all105_marisa_trie_with_redirect.pkl"
 
+# rm fairseq_multilingual_entity_disambiguation.tar.gz # remove the tar.gz file after extraction

--- a/GSoC24_H/requirements.txt
+++ b/GSoC24_H/requirements.txt
@@ -8,3 +8,22 @@ stanza
 
 #dev
 pyright
+streamlit
+torch
+tqdm
+transformers
+pytz
+psutil
+matplotlib
+scikit-learn
+python-crfsuite
+jsonlines
+toml
+fastcoref
+requests
+nltk
+graphviz
+fairseq
+marisa-trie
+sklearn-crfsuite 
+gdown # for downloading the models from google drive

--- a/GSoC24_H/src/chunking/chunking_model.py
+++ b/GSoC24_H/src/chunking/chunking_model.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 import torch.nn as nn
 import string
 from collections import Counter
-from transformers import AdamW
+from torch.optim import AdamW
 from transformers.modeling_outputs import SequenceClassifierOutput
 from sklearn.metrics import (
     classification_report,


### PR DESCRIPTION
Lot of dependencies issue so added these to the requirements file:
pyright
streamlit
torch
tqdm
transformers
pytz
psutil
matplotlib
scikit-learn
python-crfsuite
jsonlines
toml
fastcoref
requests
nltk
graphviz
fairseq
marisa-trie
sklearn-crfsuite 
gdown


Missing Files:
GSoC24_H/models/coref_model/config.toml

Misplaced Files (requiring code change or file move):
titles_lang_all105_marisa_trie_with_redirect.pkl
my_tagset_BI.bin
26_epoch_4.pth.tar
sklearn_crf_model_v2_pos_mapped_2.pkl

The config.toml (missing) would specify data_dir. if pretrained weights are expected to be loaded by coref_model.py's load_weights without a direct path, then files matching rf"{self.config.section}_\\(e(\\d+)[^()]*\\).*\\.pt" (from coref_model.py) should be in that data_dir. Once config.toml is available, ill check its data_dir if it exist and if its just referencing GSoC24_H/models/coref_model/model/xlmr_multi_plus_hi2.pt (this exists after download)

The fairseq_multilingual_entity_disambiguation model seems to be correctly referenced if the code expects it at models/fairseq_multilingual_entity_disambiguation, but it's currently inside GSoC24_H/models/EL_model/. The code in demo.py, entity_linking.py, and start.py uses mGENRE.from_pretrained("models/fairseq_multilingual_entity_disambiguation"). This will only work if the execution path makes GSoC24_H/models/EL_model/ look like GSoC24_H/models/ or if the path is adjusted in the code.
