### PR TITLE
Added missing imports, cleaned up unused types and fixed indentations

### DIFF
--- a/GSoC25/EntityLinking/test_redis.py
+++ b/GSoC25/EntityLinking/test_redis.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import redis
+import os
 import pandas as pd
 import time
-from typing import List, Dict
 
 
 class RedisEntityLinking:
@@ -16,7 +16,7 @@ class RedisEntityLinking:
          self.redis_redir = redis.Redis(host=self.host, port=self.port, password=self.password, db=1, decode_responses=True)
         
         # Test connection
-        try:
+         try:
             if self.redis_forms.ping() and self.redis_redir.ping():
                 print("Connected to Redis server successfully!")
                 print(f"Surface forms DB size: {self.redis_forms.dbsize()}")
@@ -24,7 +24,7 @@ class RedisEntityLinking:
             else:
                 print("Could not connect to Redis")
                 raise ConnectionError("Redis connection failed")
-        except Exception as e:
+         except Exception as e:
             print(f"Redis connection error: {e}")
             raise
     

--- a/GSoC25/EntityLinking/test_redis.py
+++ b/GSoC25/EntityLinking/test_redis.py
@@ -2,7 +2,6 @@
 
 import os
 import redis
-import os
 import pandas as pd
 import time
 
@@ -17,7 +16,7 @@ class RedisEntityLinking:
         self.redis_redir = redis.Redis(host=self.host, port=self.port, password=self.password, db=1, decode_responses=True)
         
         # Test connection
-         try:
+        try:
             if self.redis_forms.ping() and self.redis_redir.ping():
                 print("Connected to Redis server successfully!")
                 print(f"Surface forms DB size: {self.redis_forms.dbsize()}")
@@ -25,10 +24,10 @@ class RedisEntityLinking:
             else:
                 print("Could not connect to Redis")
                 raise ConnectionError("Redis connection failed")
-         except Exception as e:
+        except Exception as e:
             print(f"Redis connection error: {e}")
             raise
-    
+
     def calculate_redirect(self, source):
         result = self.redis_redir.get(source)
         if result is None:


### PR DESCRIPTION
This PR resolves a `NameError` that prevented `EntityLinking/test_redis.py` from executing.

**Changes:**
1. **Fixed Crash:** Added missing `import os` (required for `os.getenv` calls).
2. **Cleanup:** Removed unused imports (`List`, `Dict`) and fixed indentation to improve code compliance.

**Verification:**
Validated that the script now passes the import stage and executes without raising a `NameError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Cleaned up imports and minor formatting in Redis connection tests; adjustments are non-functional and do not change test behavior or public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->