### PR TITLE
Fix typo and indentation in test_redis.py

### DIFF
--- a/GSoC25/EntityLinking/test_redis.py
+++ b/GSoC25/EntityLinking/test_redis.py
@@ -9,11 +9,11 @@ from typing import List, Dict
 class RedisEntityLinking:
     
     def __init__(self, host=None, port=None, password=None):
-         self.host = host or os.environ.get('NEF_REDIS_HOST')
-         self.port = port or os.environ.get('NEF_REDIS_PORT')
-         self.password = password or os.environ.get('NEF_REDIS_PASSWORD')
-         self.redis_forms = redis.Redis(host=self.host, port=self.port, password=self.password, db=0, decode_responses=True)
-         self.redis_redir = redis.Redis(host=self.host, port=self.port, password=self.password, db=1, decode_responses=True)
+        self.host = host or os.environ.get('NEF_REDIS_HOST')
+        self.port = port or os.environ.get('NEF_REDIS_PORT')
+        self.password = password or os.environ.get('NEF_REDIS_PASSWORD')
+        self.redis_forms = redis.Redis(host=self.host, port=self.port, password=self.password, db=0, decode_responses=True)
+        self.redis_redir = redis.Redis(host=self.host, port=self.port, password=self.password, db=1, decode_responses=True)
         
         # Test connection
         try:
@@ -67,7 +67,7 @@ def test_redis_entity_linking():
     try:
         redis_el = RedisEntityLinking()
     except Exception as e:
-        print(f"ailed to initialize Redis: {e}")
+        print(f"Failed to initialize Redis: {e}")
         return
     
     # Test entities

--- a/GSoC25/EntityLinking/test_redis.py
+++ b/GSoC25/EntityLinking/test_redis.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import redis
 import pandas as pd
 import time


### PR DESCRIPTION
 Corrected indentation levels in 
`test_redis.py` ,
 to resolve runtime errors during initialization. also fix the typo on line 70 from **`ailed`**  to **`Failed`**
 
![WhatsApp Image 2026-01-29 at 2 20 28 PM](https://github.com/user-attachments/assets/5a98e6a2-5b75-421c-8607-9fd7052f885e)

<img width="495" height="118" alt="image" src="https://github.com/user-attachments/assets/4366691c-6f53-4a8e-9fb4-fd36dc9bd34f" />


 
 closes issue #28 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in an error message to ensure clear communication when system initialization encounters issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->