### PR TITLE
Docs: Overhaul GSoC25_H /README.md to reflect current architecture

### DIFF
--- a/GSoC25_H/README.md
+++ b/GSoC25_H/README.md
@@ -2,8 +2,6 @@
 
 **A comprehensive pipeline for extracting structured knowledge triplets from Hindi text, combining rule-based methods, neural models, and large language models.**
 
-![Status](https://img.shields.io/badge/Status-Under_Development-orange)
-![GSoC](https://img.shields.io/badge/GSoC-2026_Candidate_Work-blue)
 
 > **Note:** This documentation was updated to reflect the current state of the codebase (Feb 2026).
 
@@ -11,13 +9,13 @@
 
 ## Overview
 
-This repository contains the GSoC 2024/2025 work for the DBpedia Hindi Chapter. It implements a multi-stage information extraction pipeline that processes Hindi Wikipedia articles and produces DBpedia-compatible triplets through coreference resolution, relation extraction, entity linking, and predicate linking.
+This repository contains the DBpedia Hindi Extraction Framework, originally developed during GSoC 2024/2025 and currently being updated for the GSoC 2026 cycle.
 
 ---
 
 ## Directory Structure
 
-```
+```text
 GSoC25_H/
 ├── IndIE/                          # Rule-based extraction with LLM enhancement
 │   ├── chunking/                   # Sentence chunking models (XLM-R, CRF)
@@ -439,7 +437,7 @@ w_type = 0.1   # Type compatibility
 2. **Type Linking Not Implemented:** Currently handles only relational properties, not type assertions
 3. **SPARQL Timeouts:** Occasional timeouts on complex predicate linking queries
 4. **LLM Hallucination:** High false positive rates (50-70%) in pure LLM modes
-5. **GPU Memory:** Larger Gemma models may require higher VRam (use quantized models)
+5. **GPU Memory:** Larger Gemma models may require higher VRAM (use quantized models)
 
 ---
 

--- a/GSoC25_H/README.md
+++ b/GSoC25_H/README.md
@@ -1,192 +1,485 @@
-# Neural Hindi Wiki Triple Extraction Pipeline
+# DBpedia Hindi Extraction Framework
 
-This project aims to enhance and evaluate the relation extraction pipeline for Hindi Wikipedia articles, utilizing a combination of state-of-the-art language models and rule-based methods. 
-This repo builds on the work done in GSoC24 for the Hindi chapter.
+**A comprehensive pipeline for extracting structured knowledge triplets from Hindi text, combining rule-based methods, neural models, and large language models.**
+
+![Status](https://img.shields.io/badge/Status-Under_Development-orange)
+![GSoC](https://img.shields.io/badge/GSoC-2026_Candidate_Work-blue)
+
+> **Note:** This documentation was updated to reflect the current state of the codebase (Feb 2026).
+
+---
+
+## Overview
+
+This repository contains the GSoC 2024/2025 work for the DBpedia Hindi Chapter. It implements a multi-stage information extraction pipeline that processes Hindi Wikipedia articles and produces DBpedia-compatible triplets through coreference resolution, relation extraction, entity linking, and predicate linking.
+
+---
+
+## Directory Structure
+
+```
+GSoC25_H/
+├── IndIE/                          # Rule-based extraction with LLM enhancement
+│   ├── chunking/                   # Sentence chunking models (XLM-R, CRF)
+│   ├── hindi-benchie/              # Benchmark dataset and evaluation scripts
+│   ├── templates/                  # Flask web interface templates
+│   ├── main.py                     # Main extraction script
+│   ├── llm_extractor.py            # LLM-based extraction fallback
+│   ├── convert.py                  # H5 to text format converter
+│   └── app.py                      # Flask web application
+│
+├── llm_IE/                         # LLM evaluation framework
+│   ├── finetuning/                 # Synthetic data generation scripts
+│   ├── config.py                   # Model and experiment configuration
+│   ├── prompt_templates.py         # Multiple prompting strategies
+│   ├── llm_interface.py            # Ollama API wrapper
+│   ├── output_parser.py            # Response parsing logic
+│   ├── full_dataset_evaluation.py  # Benchmark runner
+│   └── detailed_comparison_using_benchIE.py  # Analysis script
+│
+├── ReAct/                          # Reasoning + Acting framework
+│   ├── config.py                   # ReAct-specific configuration
+│   ├── prompt_factory.py           # Prompt generation for tool calling
+│   ├── llm_interface.py            # Function-calling interface
+│   ├── data_loader.py              # Dataset loading utilities
+│   └── evaluation.py               # Evaluation metrics
+│
+├── link_prediction/                # Knowledge graph link prediction
+│   ├── data/                       # DBpedia Hindi dumps (TTL files)
+│   ├── link_prediction.ipynb       # TransE and ConvE implementations
+│   ├── hiwiki-analysis.ipynb       # Data exploration notebook
+│   └── requirements.txt            # PyKEEN and dependencies
+│
+├── src/                            # Main pipeline components
+│   ├── coref/                      # WL-Coref implementation
+│   ├── chunking/                   # Chunking model wrapper
+│   ├── wikipedia/                  # Wikipedia data reader
+│   ├── start.py                    # CLI entry point for full pipeline
+│   ├── demo.py                     # Streamlit interactive demo
+│   ├── indIE.py                    # IndIE wrapper for pipeline
+│   ├── llm_triplets.py             # LLM-based triplet extraction
+│   ├── llm_coreference.py          # LLM-based coreference resolution
+│   ├── entity_linking.py           # mGENRE entity linking
+│   ├── el_normalize.py             # Wikidata to DBpedia URI conversion
+│   ├── predicate_linking.py        # Hindi predicate to DBpedia property mapping
+│   └── utils.py                    # Shared utilities
+│
+├── models/                         # Pre-trained model storage
+│   ├── coref_model/                # WL-Coref multilingual model
+│   ├── RE_model/                   # IndIE chunking models
+│   ├── EL_model/                   # mGENRE entity linking model
+│   ├── ontology/                   # DBpedia ontology embeddings (auto-generated)
+│   └── download_models.sh          # Automated download script
+│
+├── ontology_input/                 # DBpedia ontology (TTL format)
+│   └── ontology--DEV_type=parsed.ttl
+│
+├── assets/                         # Demo screenshots
+├── requirements.txt                # Main Python dependencies
+└── README.md                       # This file
+```
+
+---
 
 ## Components
 
-### LLM_IE
-Contains code for the plug-and-play evaluation framework  for measuring how well small-language-models (SLMs) extract `(subject, relation, object)` triplets from Hindi text using the official [*Hindi-BenchIE*](https://github.com/ritwikmishra/hindi-benchie) benchmark.
+### 1. IndIE (Rule-Based Extraction)
 
-It also contains the finetuning folder which currently only has the synthetic data generation and filtering scripts. 
+**Location:** `IndIE/`
 
-Generated data and all extraction results can be found at this [Google Drive link](https://drive.google.com/drive/folders/1rYZbLRgZRwfyVJJvsxhqqODQvIrA1JCs)
+A hybrid information extraction system that combines handwritten dependency rules with optional LLM enhancement. The pipeline consists of three stages:
 
-TODO: A lot of this code overlaps with the ReAct/ module code. Can be cleaned up.
+1. **Chunking:** Breaks sentences into meaningful phrases using XLM-RoBERTa or CRF models
+2. **Merged Dependency Tree (MDT):** Identifies grammatical relationships between chunks
+3. **Extraction:** Applies 100+ handwritten rules or LLM-based extraction to generate triplets
 
+**Key Files:**
+- `main.py` - Entry point with configurable extraction modes
+- `llm_extractor.py` - LLM fallback for zero-extraction sentences
+- `convert.py` - Converts H5 output to tab-separated format
+- `chunking/chunking_model.py` - XLM-RoBERTa chunking implementation
+- `chunking/crf_chunker.py` - CRF-based chunking alternative
 
-### Link Prediction
-Performed various experiments with link prediction modules using the DBpedia hindi data upto May 2025. Few things we tried:
-- Two different KGE models - TransE & ConvE
-- Incorporating and comparing MURIL Embeddings as starting points (initial embeddings) dimensionally reduced using PCA
+**Extraction Modes (configured in `main.py`):**
+- `use_llm=True` - Replace rules with LLM entirely
+- `llm_fallback=True` - Use LLM only when rules produce zero triplets
+- `llm_enhancement=True` - Combine rule-based + LLM outputs
+- `llm_filter_mode=True` - Filter outputs using LLM
 
-Lot of scope for future work here like hyperparameter tuning, advance entity representation using embeddings of first para of wikipedia text etc. Of course using the english graph in conjunction with the hindi dataset will enhance such a model. 
+### 2. llm_IE (LLM Evaluation Framework)
 
-### IndIE Enhancement
-The idea here is simple. 
+**Location:** `llm_IE/`
 
-IndIE relies on a three-stage pipeline to produce its final output: Sentence (input) -> Chunking (P1) -> Creation of MDT (P2) -> Handwritten Rules (P3) -> Triplets (Output)
+A plug-and-play framework for evaluating Small Language Models on Hindi information extraction using the Hindi-BenchIE benchmark (112 sentences).
 
-Let’s look at what each of these phases does at a high level:
+**Features:**
+- Six prompting strategies (few-shot, chain-of-thought, evidence-based reasoning)
+- Supports any Ollama-compatible model
+- Detailed precision/recall/F1 metrics with per-sentence TP/FP/FN breakdowns
 
-1. Chunking: This is the process of breaking down the input sentence into meaningful multi-word units. Each chunk represents:
-Noun phrases (entities, objects)
-Verb phrases (actions, states)
-Prepositional phrases (relationships, locations, times)
-Other syntactic units
-For example: Sentence: कार्यरूप जगत को देखकर ही शक्तिरूपी माया की सििद्ध होती है . Chunks: [‘कार्यरूप जगत को’, ‘देखकर ही’, ‘शक्तिरूपी माया की’, ‘सििद्ध होती है’, ’.’]
+**Key Files:**
+- `config.py` - Model selection and hyperparameter settings
+- `prompt_templates.py` - Implements all prompting strategies
+- `llm_interface.py` - Ollama REST API wrapper
+- `full_dataset_evaluation.py` - Runs complete benchmark evaluation
+- `detailed_comparison_using_benchIE.py` - Generates detailed analysis
 
-2. Merged Dependency Tree: The MDT shows how chunks relate to each other grammatically, helping identify subjects, objects, and modifiers. For example for the same above sentence, we would derive the following MDT:
+**Available Strategies:**
+1. `few_shot` - English instructions with Hindi examples
+2. `few_shot_hindi` - Hindi-only instruction set
+3. `chain_of_thought` - Step-by-step reasoning in Hindi
+4. `chain_of_thought_english_hindi` - Bilingual reasoning
+5. `chain_of_thought_ER` - Evidence-based extraction in Hindi
+6. `chain_of_thought_ER_english_hindi` - Bilingual evidence-based
 
-```code
-Root Phrase: "सििद्ध होती है" (main predicate/action)
-Dependency Relations:
-  - कार्यरूप जगत को->obj
-  - देखकर ही->advcl
-  - शक्तिरूपी माया की->nmod
-  - सििद्ध होती है->root
-  - .->0
-```
+### 3. ReAct (Reasoning + Acting)
 
-3. Handwritten Rules for Triplet Extraction: For the final output, indIE uses over 100 handwritten rules to derive the final output. This is the brittle component that we want to enhance.
+**Location:** `ReAct/`
 
-The idea here was to try replacing the component of hand written rules. Instead of relying on these, we pass the chunks and MDT to a small LM like Gemma 3. We explain to Gemma 3 deeply what a dependency tree is and how it works. Once the model is provided with all this information, it should ideally be able to generate better triplets than before.
+Implements the ReAct framework using LLM native function-calling capabilities for structured triplet extraction.
 
-We ran multiple experiments here and eventually after multiple iterations we were able to achieve 66% recall up from 50% from the baseline indIE model. 
+**Key Files:**
+- `config.py` - Tool definitions and model configuration
+- `prompt_factory.py` - Generates ReAct-style prompts
+- `llm_interface.py` - Handles tool-calling API interactions
+- `evaluation.py` - Evaluates ReAct outputs against benchmarks
 
-### Predicate Linking 
-This module was an addition to the pipeline from last year to map the extracted relations to the DBpedia ontology.
-We map Hindi predicate phrases to English DBpedia ontology properties (`dbo:*`) using a hybrid approach:
+### 4. Link Prediction
 
-- Graph evidence: direct `dbo:*` edges between `dbr:S` and `dbr:O` (both directions)
-- Lexical match: SPARQL label search (Hindi/English)
-- Type compatibility: `rdfs:domain`/`rdfs:range` vs `rdf:type(S)`/`rdf:type(O)`
-- Multilingual sentence embeddings: local index over the ontology built from `GSoC24_H/ontology_input/ontology--DEV_type=parsed.ttl`
+**Location:** `link_prediction/`
 
+Knowledge Graph Embedding experiments for predicting missing links in Hindi DBpedia using TransE and ConvE models.
 
-Scoring (higher is better): 
-```python
-w_graph, w_emb, w_lex, w_type = 0.4, 0.3, 0.2, 0.1
-# weighted sum -> prioritize graph, then embedding, then lexical, then type
-score = w_graph * graph_score + w_emb * emb_score + w_lex * lex_score + w_type * type_score
-```
+**Contents:**
+- `link_prediction.ipynb` - Model training and evaluation
+- `hiwiki-analysis.ipynb` - Hindi DBpedia statistics and exploration
+- `data/` - 13 DBpedia Hindi TTL dumps (May 2025)
 
-Outputs include `property_uri`, labels, score, direction (`S->O` or `O->S`), and evidence breakdown.
+**Models Implemented:**
+- **TransE:** Translational distance embeddings
+- **ConvE:** Convolutional neural network embeddings
+- **MURIL Integration:** Uses MuRIL embeddings as initialization
 
+### 5. Main Pipeline
 
-## How to Run
-- Install dependencies by running in the GSoC25/ root 
+**Location:** `src/`
 
-```pip install -r requirements.txt```
+The production-ready extraction pipeline integrating all components.
 
-### SLM guided IE
-- Lives in llm_IE/
-- Refer llm_IE/README.md
+**Pipeline Stages:**
 
-### Link Prediction
-- Lives in link_prediction/
-- 2 notebooks - one for analysis, one for actual implementation of the models
-- Run the notebooks using jupyter individually
+1. **Coreference Resolution** (`coref/`)
+   - Model: WL-Coref (multilingual XLM-R)
+   - Resolves pronouns and entity mentions
 
-### Predicate Linking (Hindi → DBpedia Ontology)
-Implementation lives in `src/predicate_linking.py`.
+2. **Relation Extraction** (`indIE.py`, `llm_triplets.py`)
+   - Method 1: Rule-based (IndIE wrapper)
+   - Method 2: LLM-based fallback
 
-- CLI (coref → RE → EL → predicate linking):
+3. **Entity Linking** (`entity_linking.py`)
+   - Model: mGENRE (multilingual GENRE)
+   - Links Hindi entities to Wikipedia/DBpedia
+
+4. **Entity Normalization** (`el_normalize.py`)
+   - Converts mGENRE output (Wikidata IDs) to DBpedia URIs
+
+5. **Predicate Linking** (`predicate_linking.py`)
+   - Maps Hindi relation phrases to DBpedia properties
+   - Hybrid scoring: graph evidence + embeddings + lexical + types
+
+**Entry Points:**
+- `start.py` - CLI for batch processing
+- `demo.py` - Streamlit interactive interface
+
+---
+
+## Installation
+
+### Prerequisites
+
+- Python 3.8+
+- CUDA-compatible GPU (optional, recommended)
+- 16GB RAM minimum
+- Ollama (for LLM components)
+
+### Setup
+
 ```bash
-python GSoC25_H/src/start.py \
-  --input_dir GSoC25_H/input \
-  --do_coref --do_rel --do_el --do_prop_link --verbose
+# 1. Clone repository
+git clone <repository-url>
+cd GSoC25_H
+
+# 2. Create virtual environment
+python -m venv venv
+source venv/bin/activate  # Linux/Mac
+# venv\Scripts\activate   # Windows
+
+# 3. Install dependencies
+pip install -r requirements.txt
+
+# 4. Download pre-trained models
+cd models
+bash download_models.sh
+cd ..
+
+# 5. Install Ollama (for LLM components)
+# macOS: brew install ollama
+# Linux: curl -fsSL https://ollama.com/install.sh | sh
+
+# 6. Pull an LLM model
+ollama pull gemma3:4b
 ```
-Logs progress phase-wise (graph, lexical, embedding, typing, scoring) and prints top candidate.
 
-Automated creation of ontology property and embeddings files upon first run. Cached artifacts written under `GSoC25_H/models/ontology/`:
-- `dbpedia_property_catalog.json`
-- `dbpedia_property_embeddings.npy`
-- `dbpedia_property_index.json`
+### Important Notes
 
-To reset caches, delete the files above and rerun.
+**Fairseq Compatibility (PyTorch 2.0+):**
 
-### Streamlit Demo
-From inside the GSoC25_H/ folder Run
-```streamlit run src/demo.py```
+If using PyTorch 2.0 or later, modify the fairseq checkpoint loader:
 
+```python
+# File: fairseq/fairseq/checkpoint_utils.py
+# Line: 271
+# Change:
+state = torch.load(f, map_location=torch.device("cpu"))
+# To:
+state = torch.load(f, map_location=torch.device("cpu"), weights_only=False)
+```
 
-### Data
-All experiments, results and generated data was uploaded to Google Drive. Find it [here](https://drive.google.com/drive/folders/1fgbZdGAnLhIASQRKEuyOwbBFvFZvJt_R?usp=sharing). 
+---
 
+## Usage
 
-### What Work was Done
-* Streamline the existing pipeline and make it easy to run
-* Implement and evaluate new triplet extraction methods using Small Language Models (SLM)
-* Enhance the IndIE method by integrating SLMs in the last stage of IndIE
-* Implement link prediction and evaluate to predict missing links using the existing hindi KG
-* Implement predicate linking to dbpedia ontology in the existing framework
-* Deploy the SPARQL endpoint and test its performance
+### Run Full Pipeline (CLI)
 
+```bash
+python src/start.py \
+  --input_dir input/ \
+  --do_coref \
+  --do_rel \
+  --do_el \
+  --do_prop_link \
+  --verbose
+```
 
-## Progress Overview
+**Flags:**
+- `--do_coref` - Enable coreference resolution
+- `--do_rel` - Enable relation extraction
+- `--do_el` - Enable entity linking
+- `--do_prop_link` - Enable predicate linking
+- `--verbose` - Print detailed output
 
-### Week 1-2
+### Run Streamlit Demo
 
-- Streamlined the existing pipeline from GSoC'24, made it simple to run (steps below)
-- Rebased and raised final PR for addings Hindi mappings and extractors - https://github.com/dbpedia/extraction-framework/pull/776
+```bash
+streamlit run src/demo.py
+```
 
-### Week 3 
+Open browser at `http://localhost:8501` and enter a Hindi Wikipedia article name.
 
-- Simple framework for evaluating the performance of SLMs w.r.t various prompt strategies on the Hindi BenchIE dataset
-- Lives in **llm_IE/** directory
-- Read https://advenk.github.io/av-blog/posts/gsoc-25/gsoc-week-3/
+### Run IndIE Extraction
 
-### Week 4 
+```bash
+cd IndIE
 
-- Used ReAct framework for prompting
-- Link prediction setup
+# Configure extraction mode in main.py (lines 45-50)
+# Set: use_llm, llm_fallback, llm_enhancement, llm_filter_mode
 
-### Week 5
-- Link Prediction notebook completed
-- Integrated gemma into the last stage of the IndIE pipeline
+# Run extraction
+python main.py
 
-### Week 6
-- Experimented and evaluated IndIE + gemma pipeline from previous week
-- Achieved ~65% recall
-- Designed finetuning plan
+# Convert output
+python convert.py
+```
 
-### Week 7
-- Wrote the synthetic data generation script
-- Deployed and performance tested the SPARQL endpoint (lives in https://github.com/advenk/virtuoso-sparql-endpoint-quickstart/tree/gsoc25_hindi_chapter)
+### Evaluate LLMs on BenchIE
 
-### Week 8-9
-- Paper Review of "Text-to-SPARQL Goes Beyond English: Multilingual Question Answering Over Knowledge Graphs through Human-Inspired Reasoning"
-- Document the SPARQL endpoint (temporarily here: http://95.217.58.54:8890/sparql)
-- Synthetic Data Generation script change
+```bash
+cd llm_IE
 
-### Week 10
-- Evaluated code for entity linking in depth
-- Identified Gaps
-- EL setup
+# Configure models and strategies in config.py
+python full_dataset_evaluation.py
 
-### Week 11
-- Implemented predicate linking to dbpedia ontology
-- Integrated into existing pipeline
+# Generate detailed analysis
+python detailed_comparison_using_benchIE.py
+```
 
-### Week 12
-- EL normalisation to dbpedia resources from wikidata ID
-- Translated and scored lexical similarity for predicates
-- Clean up and wrap up of code
-- Consolidating a
+### Run Link Prediction
 
-## Known Limitations and Future Work
-- Enhance predicate linking to include type linking. It currently only handles relational linking but not type linking. Type linking would require us to identify if a triplet is of the form (subject, "है", object) and then link it as the subject -> type -> object. For other triplets (relational), this is handled. The major difference is the "object" in a type linking is a class in the ontology whereas in regular relational linking this is a property. 
-- Enhance link prediction using English knowledge graph, hyperparam tuning, better embeddings for disambiguation etc
-- Finetune gemma3 using latest synthetically generated data then gauge performance
-- Refine the pipeline for enhanced accuracy.
+```bash
+cd link_prediction
 
+# Open notebooks in Jupyter
+jupyter notebook
+```
 
-## Other related links
-- Weekly Blog: https://advenk.github.io/av-blog/
-- Unmerged PR for Hindi mappings and extractors: https://github.com/dbpedia/extraction-framework/pull/776 - Can be merged only after updating the mappings via UI.
+---
 
-## Archived
-- SPARQL performance testing code (not to be merged) - https://github.com/advenk/virtuoso-sparql-endpoint-quickstart/tree/gsoc25_hindi_chapter
+## Model Downloads
 
-- Hindi SPARQL temporary endpoint deployed at http://95.217.58.54:8890/sparql (archived as of 15/09/2025)
+The `models/download_models.sh` script downloads:
+
+1. **Coreference Model** (WL-Coref) - ~1.2GB
+2. **Relation Extraction Model** (IndIE Chunker) - ~500MB
+3. **Entity Linking Model** (mGENRE) - ~2.5GB
+4. **Entity Linking Trie** (Marisa Trie) - ~800MB
+
+**Manual Download Links:**
+
+| Component | Link |
+|-----------|------|
+| Coref | [Google Drive](https://drive.google.com/file/d/1ScVz_o4V3G7watezLriCC0vU5gT7FO7q) |
+| RE | [Google Drive](https://drive.google.com/file/d/1UqOUdeK96m6EabI-cg2EeBz6p3IwrPZ6) |
+| EL Model | [Facebook AI](https://dl.fbaipublicfiles.com/GENRE/fairseq_multilingual_entity_disambiguation.tar.gz) |
+| EL Trie | [Facebook AI](http://dl.fbaipublicfiles.com/GENRE/titles_lang_all105_marisa_trie_with_redirect.pkl) |
+
+---
+
+## Data Resources
+
+### Datasets
+
+- **Hindi-BenchIE:** 112-sentence gold standard for Hindi Open IE
+  - Location: `hindi-benchie/hindi_benchie_gold.txt`
+  - Format: Custom text with clusters and compensatory extractions
+
+- **DBpedia Hindi (May 2025):** Knowledge graph dumps
+  - Location: `link_prediction/data/*.ttl.bz2`
+  - Size: 13 files, ~8GB compressed
+
+- **DBpedia Ontology:** Property definitions
+  - Location: `ontology_input/ontology--DEV_type=parsed.ttl`
+
+### External Resources
+
+- **Experiment Results:** [Google Drive](https://drive.google.com/drive/folders/1rYZbLRgZRwfyVJJvsxhqqODQvIrA1JCs)
+- **Full Dataset:** [Google Drive](https://drive.google.com/drive/folders/1fgbZdGAnLhIASQRKEuyOwbBFvFZvJt_R)
+
+---
+
+## Performance Benchmarks
+
+### LLM Evaluation Results (Hindi-BenchIE)
+
+**Best Performing Configuration:**
+- **Model:** Gemma 3 4B (Quantized)
+- **Strategy:** `chain_of_thought_ER` (Evidence-Based Reasoning)
+- **F1-Score:** **25.48%**
+- **Precision:** 27.38%
+- **Recall:** 23.83%
+
+**Top 3 Model-Strategy Pairs:**
+
+| Rank | Model | Strategy | F1 | Precision | Recall |
+|------|-------|----------|----|-----------|--------|
+| 1 | gemma3:4b | chain_of_thought_ER | 25.48% | 27.38% | 23.83% |
+| 2 | gemma3:4b | chain_of_thought_ER_english_hindi | 24.92% | 28.87% | 21.93% |
+| 3 | gemma3:4b | few_shot | 14.44% | 14.36% | 14.53% |
+
+**Key Findings:**
+1. **Evidence-Based Reasoning Wins:** The `chain_of_thought_ER` strategy yielded a **75% improvement** over standard few-shot prompting.
+2. **Architecture > Scale:** The 4B parameter Gemma model outperformed the 7B Mistral model by **2.4x** on average F1 score.
+3. **Language Agnostic Reasoning:** Structured reasoning strategies performed well regardless of whether the prompts were in Hindi or English, whereas unstructured chain-of-thought failed in both.
+
+*For a detailed analysis of all 18 experiments, see `llm_IE/results_and_discussion.md`.*
+
+### IndIE Enhancement Results
+
+| Method | Recall | Notes |
+|--------|--------|-------|
+| IndIE (baseline) | 50% | Rule-based only |
+| IndIE + LLM (fallback) | 66% | +32% improvement |
+
+---
+
+## Configuration
+
+### IndIE Extraction Modes
+
+Edit `IndIE/main.py` hyperparameters:
+
+```python
+hyper_params = {
+    'use_llm': False,         # Replace rules with LLM
+    'llm_fallback': True,     # LLM only for zero-triplet sentences
+    'llm_enhancement': True,  # Combine rules + LLM
+    'llm_filter_mode': False, # LLM-based filtering
+    'llm_model': 'gemma3:4b',
+    'chunker': 'XLM',         # 'XLM' or 'CRF'
+}
+```
+
+### LLM Evaluation Setup
+
+Edit `llm_IE/config.py`:
+
+```python
+self.experiment = ExperimentConfig(
+    models=["gemma3:4b", "mistral:latest"],
+    prompt_strategies=["chain_of_thought_ER", "few_shot"],
+)
+```
+
+### Predicate Linking Weights
+
+Edit `src/predicate_linking.py`:
+
+```python
+# Scoring weights (sum to 1.0)
+w_graph = 0.4  # Direct DBpedia edges
+w_emb = 0.3    # Semantic similarity
+w_lex = 0.2    # Label matching
+w_type = 0.1   # Type compatibility
+```
+
+---
+
+## Known Issues
+
+1. **Entity Linking Disambiguation:** Common names may link incorrectly
+2. **Type Linking Not Implemented:** Currently handles only relational properties, not type assertions
+3. **SPARQL Timeouts:** Occasional timeouts on complex predicate linking queries
+4. **LLM Hallucination:** High false positive rates (50-70%) in pure LLM modes
+5. **GPU Memory:** Larger Gemma models may require higher VRam (use quantized models)
+
+---
+
+## References
+
+### Related Projects
+
+- **IndIE Paper:** [IJCNLP-AACL 2023 Findings](http://103.25.231.59:80)
+- **WL-Coref:** [GitHub](https://github.com/vdobrovolskii/wl-coref)
+- **mGENRE:** [Facebook Research](https://github.com/facebookresearch/GENRE)
+- **Hindi-BenchIE:** [GitHub](https://github.com/ritwikmishra/hindi-benchie)
+
+### DBpedia Resources
+
+- **DBpedia Downloads:** [Databus](https://databus.dbpedia.org/)
+- **Hindi Wikipedia Dumps:** [Wikimedia](https://dumps.wikimedia.org/hiwiki/)
+- **Extraction Framework:** [GitHub](https://github.com/dbpedia/extraction-framework)
+
+---
+
+## License
+
+This project integrates multiple open-source components with varying licenses. Please refer to individual component licenses:
+
+- IndIE: (Original repository license)
+- WL-Coref: MIT License
+- mGENRE: CC-BY-NC 4.0
+
+---
+
+## Acknowledgments
+
+- Google Summer of Code 2024/2025
+- DBpedia Association
+- IndIE Authors
+- Meta AI (mGENRE)
+- Hindi NLP Community (BenchIE benchmark)
+
+---
+
+**Repository Status:** Active  
+**Last Updated:** February 2026  
+**Primary Use Case:** Hindi Wikipedia knowledge extraction for DBpedia

--- a/GSoC25_H/README.md
+++ b/GSoC25_H/README.md
@@ -204,7 +204,7 @@ The production-ready extraction pipeline integrating all components.
 
 ```bash
 # 1. Clone repository
-git clone <repository-url>
+git clone https://github.com/dbpedia/neural-extraction-framework.git
 cd GSoC25_H
 
 # 2. Create virtual environment
@@ -279,7 +279,7 @@ Open browser at `http://localhost:8501` and enter a Hindi Wikipedia article name
 ```bash
 cd IndIE
 
-# Configure extraction mode in main.py (lines 45-50)
+# Configure extraction mode in main.py (Edit the 'hyper_params' dictionary)
 # Set: use_llm, llm_fallback, llm_enhancement, llm_filter_mode
 
 # Run extraction
@@ -337,15 +337,15 @@ The `models/download_models.sh` script downloads:
 ### Datasets
 
 - **Hindi-BenchIE:** 112-sentence gold standard for Hindi Open IE
-  - Location: `hindi-benchie/hindi_benchie_gold.txt`
+  - Location: `./IndIE/hindi-benchie/hindi_benchie_gold.txt`
   - Format: Custom text with clusters and compensatory extractions
 
 - **DBpedia Hindi (May 2025):** Knowledge graph dumps
-  - Location: `link_prediction/data/*.ttl.bz2`
+  - Location: `./link_prediction/data/*.ttl.bz2`
   - Size: 13 files, ~8GB compressed
 
 - **DBpedia Ontology:** Property definitions
-  - Location: `ontology_input/ontology--DEV_type=parsed.ttl`
+  - Location: `./ontology_input/ontology--DEV_type=parsed.ttl`
 
 ### External Resources
 
@@ -445,7 +445,7 @@ w_type = 0.1   # Type compatibility
 
 ### Related Projects
 
-- **IndIE Paper:** [IJCNLP-AACL 2023 Findings](http://103.25.231.59:80)
+- **IndIE Paper:** [IJCNLP-AACL 2023 Findings](https://aclanthology.org/2023.findings-ijcnlp.28/)
 - **WL-Coref:** [GitHub](https://github.com/vdobrovolskii/wl-coref)
 - **mGENRE:** [Facebook Research](https://github.com/facebookresearch/GENRE)
 - **Hindi-BenchIE:** [GitHub](https://github.com/ritwikmishra/hindi-benchie)


### PR DESCRIPTION
## Context
The current `GSoC25_H/README.md` contained weekly personal logs and outdated "TODO" notes from the 2024/2025 cycle. This made it difficult for new contributors to understand the current folder structure and component capabilities.

## Changes
I have refactored the README into standard technical documentation. It now includes:
* **Directory Structure:** A clear tree view of the `IndIE`, `llm_IE`, and `ReAct` modules.
* **Component Documentation:** Concise explanations of the extraction pipelines and benchmarks.
* **Installation & Usage:** Updated setup instructions based on the current `requirements.txt`.
* **Benchmarks:** Consolidated performance metrics for the Gemma-4B models tested in the `llm_IE` module.

## Impact
This documentation update improves the onboarding experience for future GSoC candidates and maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Project renamed to "DBpedia Hindi Extraction Framework" and README completely revamped with a modular overview and component taxonomy.
  * Added installation, CLI and Streamlit demo usage, model download/setup instructions, extraction-mode and prompting configuration examples, and end-to-end pipeline flow.
  * Included data/resource guidance, performance benchmarks, licensing/credits, known issues, and references for DBpedia-related utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->