### PR TITLE
Fix Redis CLI default parsing in NEF

### DIFF
--- a/GSoC25/NEF/NEF.py
+++ b/GSoC25/NEF/NEF.py
@@ -706,10 +706,14 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     p.add_argument("--predicates", type=str, default=None, help="Path to predicates.csv")
 
     # Redis
-    p.add_argument("--redis-host", type=str, default=os.getenv("NEF_REDIS_HOST", ""))
-    p.add_argument("--redis-port", type=int, default=int(os.getenv("NEF_REDIS_PORT", "")))
-    p.add_argument("--redis-password", type=str, default=os.getenv("NEF_REDIS_PASSWORD", ""))
+   
+    redis_host_env = os.getenv("NEF_REDIS_HOST")
+    redis_port_env = os.getenv("NEF_REDIS_PORT")
+    redis_password_env = os.getenv("NEF_REDIS_PASSWORD")
 
+    p.add_argument("--redis-host", type=str, default=redis_host_env or "127.0.0.1")
+    p.add_argument("--redis-port", type=int, default=int(redis_port_env) if redis_port_env else 6379)
+    p.add_argument("--redis-password", type=str, default=redis_password_env or "")
     return p.parse_args(argv)
 
 def _collect_sentences(args: argparse.Namespace) -> List[str]:

--- a/GSoC25/NEF/NEF.py
+++ b/GSoC25/NEF/NEF.py
@@ -711,9 +711,14 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     redis_port_env = os.getenv("NEF_REDIS_PORT")
     redis_password_env = os.getenv("NEF_REDIS_PASSWORD")
 
+    try:
+        redis_port_default = int(redis_port_env) if redis_port_env and redis_port_env.strip() else 6379
+    except ValueError:
+        redis_port_default = 6379
+
     p.add_argument("--redis-host", type=str, default=redis_host_env or "127.0.0.1")
-    p.add_argument("--redis-port", type=int, default=int(redis_port_env) if redis_port_env else 6379)
-    p.add_argument("--redis-password", type=str, default=redis_password_env or "")
+    p.add_argument("--redis-port", type=int, default=redis_port_default)
+    p.add_argument("--redis-password", type=str, default=redis_password_env or "")   
     return p.parse_args(argv)
 
 def _collect_sentences(args: argparse.Namespace) -> List[str]:


### PR DESCRIPTION
This PR fixes a small CLI/runtime issue in `GSoC25/NEF/NEF.py`.

Previously, the Redis port argument default could fail during parsing when `NEF_REDIS_PORT` was unset or empty. This caused the CLI to raise a `ValueError` before the pipeline could run, even in cases where Redis parameters were intended to be provided explicitly.

This patch makes the Redis CLI defaults safer by using a proper fallback value instead of directly parsing an empty environment variable.

I encountered this issue while testing the current NEF pipeline locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redis connection defaults now read from the environment with sensible fallbacks for host, port, and password, improving reliability when configuration is incomplete.
  * Added a parsing guard for the port value so invalid inputs fall back to the standard Redis port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->