### PR TITLE
Update embedding model defaults for Gemini API compatibility

### DIFF
--- a/GSoC25/NEF/Emeddings.py
+++ b/GSoC25/NEF/Emeddings.py
@@ -10,7 +10,7 @@ if not API_KEY:
     API_KEY = getpass("Enter your Gemini API key: ").strip()
 
 # == Gemini Embeddings REST (batch) ==
-BATCH_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/embedding-001:batchEmbedContents"
+BATCH_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents"
 HEADERS = {"Content-Type": "application/json"}
 
 # ==== Helpers ====
@@ -93,7 +93,7 @@ def make_requests_payload(text_batch):
     requests_payload = []
     for text in text_batch:
         requests_payload.append({
-            "model": "models/embedding-001",
+            "model": "models/gemini-embedding-001",
             "content": {"parts": [{"text": text}]},
             "outputDimensionality": OUTPUT_DIM,
             # Optional: "taskType": "RETRIEVAL_DOCUMENT",

--- a/GSoC25/NEF/NEF.py
+++ b/GSoC25/NEF/NEF.py
@@ -145,7 +145,7 @@ class PredicateEmbeddingRetriever:
         client: "genai.Client",
         embeddings_path: Optional[str] = None,
         predicates_path: Optional[str] = None,
-        embed_model: str = "embedding-001",
+        embed_model: str = "gemini-embedding-001",
         verbose: bool = True,
     ):
         self.client = client
@@ -446,7 +446,7 @@ class EnhancedNEFPipeline:
             client=self.client,
             embeddings_path=embeddings_path,
             predicates_path=predicates_path,
-            embed_model="embedding-001",
+            embed_model="gemini-embedding-001",
             verbose=verbose,
         )
         self.llm = LLMDisambiguator(
@@ -696,7 +696,7 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     # Gemini / models
     p.add_argument("--api-key", type=str, default=None, help="Gemini API key (or set GEMINI_API_KEY).")
     p.add_argument("--llm-model", type=str, default="gemini-2.5-flash", help="LLM for disambiguation/generation.")
-    p.add_argument("--embed-model", type=str, default="embedding-001", help="Embedding model name.")
+    p.add_argument("--embed-model", type=str, default="gemini-embedding-001", help="Embedding model name.")
     p.add_argument("--predicate-threshold", type=float, default=0.5, help="Similarity threshold to accept a predicate.")
     p.add_argument("--new-predicate-namespace", type=str, default="http://nef.local/rel/",
                    help="Namespace for generated predicates.")


### PR DESCRIPTION
This PR updates the default embedding model names used in the current GSoC25 NEF workflow to match the currently supported Gemini embedding API.

While testing the predicate artifact generation and retrieval workflow locally, I encountered model resolution errors with the older embedding model defaults. This patch updates the endpoint and default model settings to the currently working Gemini embedding model so that the local setup path is consistent with the active API behavior.

This is intended as a small compatibility/setup fix for the current pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Updated the embedding model to the latest version for improved consistency and compatibility.
  * Enhanced command-line interface support for selecting different embedding models during pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->