### PR TITLE
Remove sys.path modification from collector tests

### DIFF
--- a/GSoC25/Data/test_collector_functions.py
+++ b/GSoC25/Data/test_collector_functions.py
@@ -1,17 +1,18 @@
 # Test file for the new collector.py functions
+#
+# Run from the repository root:
+# python -m GSoC25.Data.test_collector_functions
 
-import sys
-from pathlib import Path
 import argparse
 
-# Add project root to Python path
-try:
-    script_path = Path(__file__).resolve()
-    PROJECT_ROOT = script_path.parent.parent.parent  # Go up 3 levels to reach project root
-except NameError:
-    PROJECT_ROOT = Path().resolve()
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
+from GSoC25.Data.collector import (
+    get_sentences_with_entities,
+    get_predicates_between,
+    get_entity_types,
+    get_text_of_wiki_page
+)
+
+import argparse
 
 from GSoC25.Data.collector import (
     get_sentences_with_entities,


### PR DESCRIPTION
## Summary

This PR addresses #39 by removing the runtime `sys.path` modification from `GSoC25/Data/test_collector_functions.py`.

### Changes

- Removed the manual `sys.path` manipulation and `Path` logic.
- Kept the existing package import:
  `from GSoC25.Data.collector import ...`
- The test module can now be executed using Python's standard module execution:

### Testing
python -m GSoC25.Data.test_collector_functions
Tested the updated test module using the command above.

The predicate and entity-type collector tests execute successfully and return results as expected.

### Test Output
<!-- Screenshot of the test output -->

<img width="922" height="725" alt="image" src="https://github.com/user-attachments/assets/1c992f2d-a9f8-42d3-bf8e-008dac494e3d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test execution guidance to clarify that tests should be run from the repository root.
  * Simplified test imports for more consistent execution and maintenance.
* **Chores**
  * Removed unnecessary path-resolution setup from the test script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->